### PR TITLE
Feature plugin tester

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,3 +1,5 @@
+.. module:: flogin
+
 API Reference
 =============
 
@@ -119,6 +121,12 @@ JSON-RPC Errors
     :members:
 
 .. autoclass:: flogin.jsonrpc.errors.JsonRPCVersionMismatch
+    :members:
+
+Testing
+-------
+
+.. autoclass:: flogin.testing.plugin_tester.PluginTester
     :members:
 
 Utils

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -123,6 +123,8 @@ JSON-RPC Errors
 .. autoclass:: flogin.jsonrpc.errors.JsonRPCVersionMismatch
     :members:
 
+.. _testing_module_api_reference:
+
 Testing
 -------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,3 +35,4 @@ If you're having trouble with something, these resources might help.
    search_handlers
    cli
    whats_new
+   testing

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -1,0 +1,117 @@
+Testing your plugin
+===================
+
+Writing Tests
+--------------
+For writing tests, we can use the :class:`~flogin.testing.plugin_tester.PluginTester` class to create tests for our plugin.
+
+:class:`~flogin.testing.plugin_tester.PluginTester` takes 3 arguments:
+
+1. Your plugin
+
+2. `Your plugin's metadata <#your-plugin-metadata>`_
+
+3. `Your FlowLauncherAPI replacement <#your-flowlauncherapi-replacement>`_
+
+*check out the hyperlinked sections for more information on those arguments*
+
+Once you have your tester instance all set up, you can use the :func:`~flogin.testing.plugin_tester.PluginTester.test_query` to test your search handlers.
+
+To test your result's context menu, the :func:`~flogin.testing.plugin_tester.PluginTester.test_context_menu` method has been provided to test your context menus.
+
+to test your result's callbacks, simply call their callbacks manually (:func:`~flogin.jsonrpc.results.Result.callback`).
+
+Example
+~~~~~~~
+Here is a simple plugin: ::
+
+    from flogin import Plugin, Query, Result, ExecuteResponse
+
+    my_plugin = Plugin()
+
+    class MyResult(Result):
+        async def callback(self):
+            await my_plugin.api.show_notification("Flogin", "result's callback has been triggered")
+            return ExecuteResponse()
+
+    @my_plugin.search()
+    async def blanket(q: Query):
+        return MyResult("Blanket Handler Called")
+
+And here is a simply testing script for it: ::
+
+    import asyncio
+
+    from flogin.testing import PluginTester
+    from flogin import Query
+
+    # Since we use the `show_notification` api method in our result callback, we need to impliment it in our replacement class.
+    class FakeFlowAPI:
+        async def show_notification(self, *args):
+            print(f"showing notification with {args!r}")
+
+
+    async def main():
+        # Because we don't use the metadata at all, we can just use some bogus data.
+        metadata = PluginTester.create_bogus_plugin_metadata()
+        
+        # Creating our plugin tester object
+        tester = PluginTester(my_plugin, metadata=metadata, flow_api_client=FakeFlowAPI())
+
+        # Creating our query object. In this example, this query would represent a query which was `bambo`, with our plugin's keyword being `bambo`.
+        query = Query(
+            raw_text="bambo",
+            keyword="bambo",
+            text="",
+        )
+
+        # Testing our search handlers and getting the response
+        response = await tester.test_query(query)
+
+        # getting our result
+        result = response.results[0]
+
+        # printing out result's title
+        print(f"Result title: {result.title}")
+
+        # Executing our result's callback
+        await result.callback()
+
+
+    asyncio.run(main())
+
+Your Plugin metadata
+~~~~~~~~~~~~~~~~~~~~
+If you pass ``None`` to the ``metadata`` argument, flogin will attempt to retrieve the metadata from your ``plugin.json`` file.
+
+In cases where that is not available or you need to customize your metadata, the :func:`~flogin.testing.plugin_tester.PluginTester.create_bogus_plugin_metadata` and :func:`~flogin.testing.plugin_tester.PluginTester.create_plugin_metadata` methods have been provided.
+
+The :func:`~flogin.testing.plugin_tester.PluginTester.create_plugin_metadata` classmethod provides a cleaner ui for creating a :class:`~flogin.flow_api.plugin_metadata.PluginMetadata` object, with some arguments being optional, and being auto-generated.
+
+The :func:`~flogin.testing.plugin_tester.PluginTester.create_bogus_plugin_metadata` provides a very fast way to generate a "valid" metadata object, by filling it with random data.
+
+Your FlowLauncherAPI replacement
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If you do not use :class:`~flogin.flow_api.client.FlowLauncherAPI` in the code that you are testing, then the default filler object will do just fine.
+
+However if you use the api at all in the code you want to test, you will want to create a FlowLauncherAPI replacement class for testing and pass it to the ``flow_api_client`` argument in your plugin tester's constructor.
+
+When creating your replacement class, make sure to impliment any and all API methods that you use, and respond accordingly inside of them.
+
+For example, lets say I use the :func:`~flogin.flow_api.client.FlowLauncherAPI.open_settings_menu` method. I would impliment that method into my replacement class, which might look something like this: ::
+
+    class MyFlowAPI:
+        async def open_settings_menu(self):
+            print("-- Settings menu has been opened --")
+
+That one is pretty easy due to it not returning anything, or doing anything that may affect the plugin. Let's take another example, :func:`~flogin.flow_api.client.FlowLauncherAPI.open_settings_menu`. You can always do something similiar to what we did with :func:`~flogin.flow_api.client.FlowLauncherAPI.open_settings_menu`, however for this example we will handle what will happen if we try to add a keyword to our own plugin. To do this, we will pass our plugin to our api class, and later use that to check the plugin ids, and add the keyword. ::
+
+    class MyFlowAPI:
+        def __init__(self, plugin):
+            self.plugin = plugin
+
+        async def add_keyword(self, plugin_id: str, keyword: str):
+            if plugin_id == self.plugin.metadata.id:
+                self.plugin.metadata.keywords.append(keyword)
+
+            print(f"-- Added {keyword!r} keyword to {plugin_id!r} --")

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -196,4 +196,4 @@ Good next steps:
 
 - `pytest-asyncio docs <https://pytest-asyncio.readthedocs.io/en/latest/index.html>`_
 - `pytest docs <https://docs.pytest.org/en/stable/index.html>`_
-- `Testing Module API Reference <testing_module_api_reference>`_
+- :ref:`Testing Module API Reference <testing_module_api_reference>`

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -1,5 +1,3 @@
-.. module:: flogin
-
 Whats New
 ==========
 

--- a/example.py
+++ b/example.py
@@ -1,11 +1,15 @@
-from flogin import Plugin, Query, Result, ExecuteResponse
+from flogin import ExecuteResponse, Plugin, Query, Result
 
 my_plugin = Plugin()
 
+
 class MyResult(Result):
     async def callback(self):
-        await my_plugin.api.show_notification("Flogin", "result's callback has been triggered")
+        await my_plugin.api.show_notification(
+            "Flogin", "result's callback has been triggered"
+        )
         return ExecuteResponse()
+
 
 @my_plugin.search()
 async def blanket(q: Query):
@@ -14,8 +18,9 @@ async def blanket(q: Query):
 
 import asyncio
 
-from flogin.testing import PluginTester
 from flogin import Query
+from flogin.testing import PluginTester
+
 
 # Since we use the `show_notification` api method in our result callback, we need to impliment it in our replacement class.
 class FakeFlowAPI:
@@ -26,7 +31,7 @@ class FakeFlowAPI:
 async def main():
     # Because we don't use the metadata at all, we can just use some bogus data.
     metadata = PluginTester.create_bogus_plugin_metadata()
-    
+
     # Creating our plugin tester object
     tester = PluginTester(my_plugin, metadata=metadata, flow_api_client=FakeFlowAPI())
 

--- a/example.py
+++ b/example.py
@@ -1,0 +1,53 @@
+from flogin import Plugin, Query, Result, ExecuteResponse
+
+my_plugin = Plugin()
+
+class MyResult(Result):
+    async def callback(self):
+        await my_plugin.api.show_notification("Flogin", "result's callback has been triggered")
+        return ExecuteResponse()
+
+@my_plugin.search()
+async def blanket(q: Query):
+    return MyResult("Blanket Handler Called")
+
+
+import asyncio
+
+from flogin.testing import PluginTester
+from flogin import Query
+
+# Since we use the `show_notification` api method in our result callback, we need to impliment it in our replacement class.
+class FakeFlowAPI:
+    async def show_notification(self, *args):
+        print(f"showing notification with {args!r}")
+
+
+async def main():
+    # Because we don't use the metadata at all, we can just use some bogus data.
+    metadata = PluginTester.create_bogus_plugin_metadata()
+    
+    # Creating our plugin tester object
+    tester = PluginTester(my_plugin, metadata=metadata, flow_api_client=FakeFlowAPI())
+
+    # Creating our query object. In this example, this query would represent a query which was `bambo`, with our plugin's keyword being `bambo`.
+    query = Query(
+        raw_text="bambo",
+        keyword="bambo",
+        text="",
+    )
+
+    # Testing our search handlers and getting the response
+    response = await tester.test_query(query)
+
+    # getting our result
+    result = response.results[0]
+
+    # printing out result's title
+    print(f"Result title: {result.title}")
+
+    # Executing our result's callback
+    await result.callback()
+
+
+asyncio.run(main())

--- a/flogin/_types.py
+++ b/flogin/_types.py
@@ -6,7 +6,7 @@ if TYPE_CHECKING:
     from .plugin import Plugin
     from .query import Query
 
-    PluginT = TypeVar("PluginT", bound=Plugin)
+    PluginT = TypeVar("PluginT", bound=Plugin, default=Plugin)
 else:
     Query = Any
     PluginT = TypeVar("PluginT")

--- a/flogin/jsonrpc/results.py
+++ b/flogin/jsonrpc/results.py
@@ -429,3 +429,6 @@ class Result(Base, Generic[PluginT]):
                 "QWERTYUIOPASDFGHJKLZXCVBNMqwertyuiopasdfghjklzxcvbnm1234567890", k=15
             )
         )
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__} {self.title=} {self.sub=} {self.icon=} {self.title_highlight_data=} {self.title_tooltip=} {self.sub_tooltip=} {self.copy_text=} {self.score=} {self.auto_complete_text=} {self.preview=} {self.progress_bar=} {self.rounded_icon=} {self.glyph=}>"

--- a/flogin/testing/__init__.py
+++ b/flogin/testing/__init__.py
@@ -1,0 +1,1 @@
+from .plugin_tester import *

--- a/flogin/testing/filler.py
+++ b/flogin/testing/filler.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+class FillerObject:
+    def __init__(self, text: str):
+        self.__error_text__ = text
+
+    def __getattribute__(self, name: str) -> Any:
+        if name == "__error_text__":
+            return super().__getattribute__(name)
+
+        raise RuntimeError(self.__error_text__)

--- a/flogin/testing/plugin_tester.py
+++ b/flogin/testing/plugin_tester.py
@@ -37,7 +37,7 @@ class PluginTester(Generic[PluginT]):
         Your plugin's metadata. If ``None`` is passed, flogin will attempt to get the metadata from your ``plugin.json`` file. The :func:`PluginTester.create_plugin_metadata` and :func:`PluginTester.create_bogus_plugin_metadata` classmethods have been provided for creating :class:`~flogin.flow_api.plugin_metadata.PluginMetadata` objects.
     flow_api_client: Optional[Any]
         If not passed, flogin will use a filler class which will raise a runtime error whenever an attribute is accessed. If passed, you should be passing an instance of a class which will replace :class:`~flogin.flow_api.client.FlowLauncherAPI`, so make sure to impliment the methods you need and handle them accordingly.
-    
+
     Attributes
     ----------
     plugin: :class:`~flogin.plugin.Plugin`
@@ -109,7 +109,7 @@ class PluginTester(Generic[PluginT]):
         if coro is None:
             raise RuntimeError("Query event handler not found")
 
-        return await coro # type: ignore
+        return await coro  # type: ignore
 
     async def test_context_menu(
         self, result: Result, *, bypass_registration: bool = False
@@ -213,7 +213,7 @@ class PluginTester(Generic[PluginT]):
             The plugin's main keyword. Defaults to the first keyword in the keywords parameter
         icon_path: Optional[:class:`str`]
             The plugin's icon. Defaults to an invalid icon path.
-        
+
         Returns
         --------
         :class:`~flogin.flow_api.plugin_metadata.PluginMetadata`

--- a/flogin/testing/plugin_tester.py
+++ b/flogin/testing/plugin_tester.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import json
+import os
+import random
+import sys
+import uuid
+from typing import TYPE_CHECKING, Any, Generic
+
+from .._types import PluginT, RawSettings
+from ..flow_api.plugin_metadata import PluginMetadata
+from ..settings import Settings
+from ..utils import MISSING
+from .filler import FillerObject
+
+if TYPE_CHECKING:
+    from ..jsonrpc.responses import QueryResponse
+    from ..jsonrpc.results import Result
+    from ..query import Query
+
+API_FILLER_TEXT = "FlowLauncherAPI is unavailable during testing. Consider passing the 'flow_api_client' arg into PluginTester to impliment your own flow api client."
+CHARACTERS = "qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLLZXCVBNM1234567890"
+
+__all__ = ("PluginTester",)
+
+
+class PluginTester(Generic[PluginT]):
+    r"""This can be used to write tests for your plugins.
+
+    See the :doc:`testing` guide for more information on writing tests.
+
+    Parameters
+    ----------
+    plugin: :class:`~flogin.plugin.Plugin`
+        Your plugin
+    metadata: :class:`~flogin.flow_api.plugin_metadata.PluginMetadata` | dict[str, Any] | None
+        Your plugin's metadata. If ``None`` is passed, flogin will attempt to get the metadata from your ``plugin.json`` file. The :func:`PluginTester.create_plugin_metadata` and :func:`PluginTester.create_bogus_plugin_metadata` classmethods have been provided for creating :class:`~flogin.flow_api.plugin_metadata.PluginMetadata` objects.
+    flow_api_client: Optional[Any]
+        If not passed, flogin will use a filler class which will raise a runtime error whenever an attribute is accessed. If passed, you should be passing an instance of a class which will replace :class:`~flogin.flow_api.client.FlowLauncherAPI`, so make sure to impliment the methods you need and handle them accordingly.
+    
+    Attributes
+    ----------
+    plugin: :class:`~flogin.plugin.Plugin`
+        Your plugin
+    """
+
+    plugin: PluginT
+
+    def __init__(
+        self,
+        plugin: PluginT,
+        *,
+        metadata: PluginMetadata | dict[str, Any] | None,
+        flow_api_client: Any = MISSING,
+    ) -> None:
+        self.plugin = plugin
+
+        if metadata is None:
+            if not os.path.exists("plugin.json"):
+                raise ValueError(
+                    "plugin.json file can not be located, consider passing the metadata instead"
+                )
+            with open("plugin.json", "r") as f:
+                metadata = json.load(f)
+            assert metadata
+
+        if isinstance(metadata, dict):
+            metadata = PluginMetadata(metadata, self.plugin.api)
+
+        self.plugin._metadata = metadata
+
+        if flow_api_client is MISSING:
+            flow_api_client = FillerObject(API_FILLER_TEXT)
+
+        self.plugin.api = flow_api_client
+        self.plugin.metadata._flow_api = flow_api_client
+
+    async def test_query(
+        self, query: Query, *, settings: Settings | RawSettings | None = MISSING
+    ) -> QueryResponse:
+        r"""|coro|
+
+        This coroutine can be used to send your plugin a query, and get the response.
+
+        Parameters
+        ----------
+        query: :class:`~flogin.query.Query`
+            The query object that should be passed to your search handlers.
+        settings: Optional[:class:`~flogin.settings.Settings` | dict[str, Any] | None]
+            This will represent the settings that flogin will use when executing your search handlers. If not passed, flogin will not use any settings. If ``None`` is passed, flogin will get the settings from the settings file (this is incompatible with :func:`PluginTester.create_bogus_plugin_metadata`). If a dict or :class:`~flogin.settings.Settings` object is passed, those are the settings that will be put in :attr:`~flogin.plugin.Plugin.settings` before executing your search handlers.
+
+        Returns
+        -------
+        :class:`~flogin.jsonrpc.responses.QueryResponse`
+            The query response object that would normally be sent to flow.
+        """
+
+        if isinstance(settings, dict):
+            settings = Settings(settings)
+        if settings is MISSING:
+            settings = Settings({})
+
+        if isinstance(settings, Settings):
+            self.plugin.settings = settings
+            self.plugin._settings_are_populated = True
+
+        coro = self.plugin.process_search_handlers(query)
+
+        if coro is None:
+            raise RuntimeError("Query event handler not found")
+
+        return await coro # type: ignore
+
+    async def test_context_menu(
+        self, result: Result, *, bypass_registration: bool = False
+    ) -> QueryResponse:
+        r"""|coro|
+
+        This coroutine can be used to send a result's context menu, and get the response.
+
+        .. NOTE::
+            You should use this to test your context menus instead of invoking them directly because this method impliments the post-processing that flogin puts onto your context menu and query methods.
+
+        Parameters
+        ----------
+        result: :class:`~flogin.jsonrpc.results.Result`
+            The result you want to invoke the context menu for.
+        bypass_registration: :class:`bool`
+            Whether or not to bypass the ``Result has not been registered`` error.
+
+        Raises
+        ------
+        ValueError
+            This will be raised when ``bypass_registration`` is set to ``False``, and the given result has not been registered.
+
+        Returns
+        -------
+        :class:`~flogin.jsonrpc.responses.QueryResponse`
+            The query response object that would normally be sent to flow.
+        """
+
+        coro = self.plugin.dispatch("context_menu", [result.slug])
+
+        if coro is None:
+            if bypass_registration:
+                self.plugin._results[result.slug] = result
+                return await self.test_context_menu(result)
+
+            raise ValueError("Result has not been registered.")
+
+        return await coro  # type: ignore
+
+    @classmethod
+    def create_bogus_plugin_metadata(cls: type[PluginTester]) -> PluginMetadata:
+        r"""This classmethod can be used to easily and quickly create a :class:`~flogin.flow_api.plugin_metadata.PluginMetadata` object that can be used for testing.
+
+        .. NOTE::
+            Since the information that this classmethod generates is bogus, it is not recommended to use this when your plugin relies on the plugin metadata. Consider using :func:`PluginTester.create_plugin_metadata` instead.
+
+        Returns
+        --------
+        :class:`~flogin.flow_api.plugin_metadata.PluginMetadata`
+            The :class:`~flogin.flow_api.plugin_metadata.PluginMetadata` instance with your bogus information.
+        """
+
+        return cls.create_plugin_metadata(
+            id=str(uuid.uuid4()),
+            name="".join(random.choices(CHARACTERS, k=10)),
+            author="".join(random.choices(CHARACTERS, k=5)),
+            version="1.0.0",
+            description="A plugin with bogus metadata to test",
+        )
+
+    @classmethod
+    def create_plugin_metadata(
+        cls: type[PluginTester],
+        *,
+        id: str,
+        name: str,
+        author: str,
+        version: str,
+        description: str,
+        website: str | None = None,
+        disabled: bool = False,
+        directory: str | None = None,
+        keywords: list[str] | None = None,
+        main_keyword: str | None = None,
+        icon_path: str | None = None,
+    ) -> PluginMetadata:
+        r"""This classmethod can be used to easily create a valid :class:`~flogin.flow_api.plugin_metadata.PluginMetadata` object that has correct data.
+
+        Parameters
+        -----------
+        id: :class:`str`
+            The plugin's id
+        name: :class:`str`
+            The plugin's name
+        author: :class:`str`
+            The plugin's author
+        version: :class:`str`
+            The plugin's version
+        description: :class:`str`
+            The plugin's description
+        website: Optional[:class:`str`]
+            The plugin's website. If not given, the following fstring will be used instead: ``f"https://github.com/{author}/{name}"``
+        disabled: Optional[:class:`bool`]
+            Whether or not to mark the plugin as disabled. Defaults to ``False``
+        directory: Optional[:class:`str`]
+            The plugin's directory. Defaults to the current working directory.
+        keywords: Optional[list[:class:`str`]]
+            The plugin's keywords. Defaults to ``["*"]``
+        main_keyword: Optional[:class:`str`]
+            The plugin's main keyword. Defaults to the first keyword in the keywords parameter
+        icon_path: Optional[:class:`str`]
+            The plugin's icon. Defaults to an invalid icon path.
+        
+        Returns
+        --------
+        :class:`~flogin.flow_api.plugin_metadata.PluginMetadata`
+            Your new metadata class.
+        """
+
+        action_keywords: list[str] = keywords or ["*"]
+        try:
+            main_keyword = main_keyword or action_keywords[0]
+        except IndexError:
+            main_keyword = "*"
+
+        data = {
+            "id": id,
+            "name": name,
+            "author": author,
+            "version": version,
+            "language": "python_v2",
+            "description": description,
+            "website": website or f"https://github.com/{author}/{name}",
+            "disabled": disabled,
+            "pluginDirectory": directory or os.getcwd(),
+            "actionKeywords": action_keywords,
+            "main_keyword": main_keyword,
+            "executeFilePath": sys.argv[0],
+            "icoPath": icon_path or "",
+        }
+
+        return PluginMetadata(data, FillerObject(API_FILLER_TEXT))  # type: ignore

--- a/flogin/testing/plugin_tester.py
+++ b/flogin/testing/plugin_tester.py
@@ -69,6 +69,16 @@ class PluginTester(Generic[PluginT]):
 
         self.plugin._metadata = metadata
 
+        self.set_flow_api_client(flow_api_client)
+
+    def set_flow_api_client(self, flow_api_client: Any = MISSING) -> None:
+        r"""This sets the flow api client that the tests should use.
+
+        Parameters
+        ----------
+        flow_api_client: Optional[Any]
+            If not passed, flogin will use a filler class which will raise a runtime error whenever an attribute is accessed. If passed, you should be passing an instance of a class which will replace :class:`~flogin.flow_api.client.FlowLauncherAPI`, so make sure to impliment the methods you need and handle them accordingly.
+        """
         if flow_api_client is MISSING:
             flow_api_client = FillerObject(API_FILLER_TEXT)
 
@@ -243,3 +253,6 @@ class PluginTester(Generic[PluginT]):
         }
 
         return PluginMetadata(data, FillerObject(API_FILLER_TEXT))  # type: ignore
+
+    def __repr__(self):
+        return f"<PluginTester id={id(self)} {self.plugin=}>"

--- a/flogin/utils.py
+++ b/flogin/utils.py
@@ -139,7 +139,11 @@ def cached_gen(gen: AGenT) -> AGenT:
     return inner  # type: ignore
 
 
-def setup_logging(*, formatter: logging.Formatter | None = None) -> None:
+def setup_logging(
+    *,
+    formatter: logging.Formatter | None = None,
+    handler: logging.Handler | None = None,
+) -> None:
     r"""Sets up flogin's default logger.
 
     Parameters
@@ -150,9 +154,10 @@ def setup_logging(*, formatter: logging.Formatter | None = None) -> None:
 
     level = logging.DEBUG
 
-    handler = logging.handlers.RotatingFileHandler(
-        "flogin.log", maxBytes=1000000, encoding="UTF-8"
-    )
+    if handler is None:
+        handler = logging.handlers.RotatingFileHandler(
+            "flogin.log", maxBytes=1000000, encoding="UTF-8"
+        )
 
     if formatter is None:
         dt_fmt = "%Y-%m-%d %H:%M:%S"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,4 +40,5 @@ packages = [
     "flogin",
     "flogin.flow_api",
     "flogin.jsonrpc",
+    "flogin.testing"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,6 @@ packages = [
     "flogin.jsonrpc",
     "flogin.testing"
 ]
+
+[tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "module"


### PR DESCRIPTION
## Summary

Implements half of #10 by adding a testing module for testing plugins.

This is necessary because to run plugins manually to test them at all, some monkeypatching is needed.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
