### PR TITLE
add state to objects

### DIFF
--- a/flogin/default_events.py
+++ b/flogin/default_events.py
@@ -26,11 +26,13 @@ async def on_error(
 
 def get_default_events(plugin: Plugin[Any]) -> dict[str, Callable[..., Awaitable[Any]]]:
     def on_query(data: dict[str, Any], raw_settings: dict[str, Any]):
-        query = Query.from_json(data)
+        query = Query(data, plugin)
         if plugin._settings_are_populated is False:
             LOG.info(f"Settings have not been populated yet, creating a new instance")
             plugin._settings_are_populated = True
-            plugin.settings = Settings(raw_settings, no_update=plugin.options.get("settings_no_update", False))
+            plugin.settings = Settings(
+                raw_settings, no_update=plugin.options.get("settings_no_update", False)
+            )
         else:
             plugin.settings._update(raw_settings)
         return plugin.process_search_handlers(query)

--- a/flogin/plugin.py
+++ b/flogin/plugin.py
@@ -39,7 +39,7 @@ from .utils import MISSING, cached_property, coro_or_gen, setup_logging
 if TYPE_CHECKING:
     from typing_extensions import TypeVar
 
-    from ._types import SearchHandlerCallback, SearchHandlerCondition, RawSettings
+    from ._types import RawSettings, SearchHandlerCallback, SearchHandlerCondition
 
     SettingsT = TypeVar("SettingsT", default=Settings, bound=Settings)
 else:
@@ -89,7 +89,7 @@ class Plugin(Generic[SettingsT]):
         self._settings_are_populated = True
         LOG.debug(f"Settings filled from file: {data!r}")
         sets = Settings(data, no_update=self.options.get("settings_no_update", False))
-        return sets # type: ignore
+        return sets  # type: ignore
 
     async def _run_event(
         self,

--- a/flogin/testing/plugin_tester.py
+++ b/flogin/testing/plugin_tester.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Generic
 
 from .._types import PluginT, RawSettings
 from ..flow_api.plugin_metadata import PluginMetadata
+from ..query import Query
 from ..settings import Settings
 from ..utils import MISSING
 from .filler import FillerObject
@@ -16,7 +17,6 @@ from .filler import FillerObject
 if TYPE_CHECKING:
     from ..jsonrpc.responses import QueryResponse
     from ..jsonrpc.results import Result
-    from ..query import Query
 
 API_FILLER_TEXT = "FlowLauncherAPI is unavailable during testing. Consider passing the 'flow_api_client' arg into PluginTester to impliment your own flow api client."
 CHARACTERS = "qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLLZXCVBNM1234567890"
@@ -88,7 +88,12 @@ class PluginTester(Generic[PluginT]):
         self.plugin.metadata._flow_api = flow_api_client
 
     async def test_query(
-        self, query: Query, *, settings: Settings | RawSettings | None = MISSING
+        self,
+        text: str,
+        *,
+        keyword: str = "*",
+        is_requery: bool = False,
+        settings: Settings | RawSettings | None = MISSING,
     ) -> QueryResponse:
         r"""|coro|
 
@@ -115,6 +120,16 @@ class PluginTester(Generic[PluginT]):
         if isinstance(settings, Settings):
             self.plugin.settings = settings
             self.plugin._settings_are_populated = True
+
+        query = Query(
+            {
+                "rawQuery": f"{keyword} {text}",
+                "search": text,
+                "actionKeyword": keyword,
+                "isReQuery": is_requery,
+            },
+            self.plugin,
+        )
 
         coro = self.plugin.process_search_handlers(query)
 

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -10,16 +10,33 @@ from flogin import (
     Query,
     RegexCondition,
 )
+from flogin.testing.filler import FillerObject
+
+
+def _create_query(text: str, plugin, keyword: str = "*", is_requery: bool = False):
+    return Query(
+        {
+            "rawQuery": f"{keyword} {text}",
+            "search": text,
+            "actionKeyword": keyword,
+        },
+        plugin,
+    )
 
 
 @pytest.fixture
-def yes_query():
-    return Query(raw_text="bar foo", text="foo", keyword="bar")
+def plugin():
+    return FillerObject(f"Fake plugin object provided")
 
 
 @pytest.fixture
-def no_query():
-    return Query(raw_text="car foo", text="apple", keyword="car")
+def yes_query(plugin):
+    return _create_query(text="foo", keyword="bar", plugin=plugin)
+
+
+@pytest.fixture
+def no_query(plugin):
+    return _create_query(text="apple", keyword="car", plugin=plugin)
 
 
 @pytest.fixture(params=[0, 1])

--- a/tests/test_search_handlers.py
+++ b/tests/test_search_handlers.py
@@ -19,14 +19,6 @@ def tester(plugin, metadata):
     return PluginTester(plugin, metadata=metadata)
 
 
-@pytest.fixture
-def query():
-    txt = "bar"
-    keyword = "foo"
-
-    return Query(raw_text=f"{txt} {keyword}", text=txt, keyword=keyword)
-
-
 class ReturnSingleResultHandler(SearchHandler):
     async def callback(self, query: Query):
         return Result("Title")
@@ -75,7 +67,7 @@ def handler(plugin: Plugin, request: pytest.FixtureRequest):
 
 
 @pytest.mark.asyncio
-async def test_handler_result(tester: PluginTester, query: Query):
-    response = await tester.test_query(query)
+async def test_handler_result(tester: PluginTester):
+    response = await tester.test_query("bar", keyword="foo")
     result = response.results[0]
     assert result.title == "Title"


### PR DESCRIPTION
## Summary

Add state to objects for easier times using them with methods such as API methods.
Classes changed so far:
- Query

## Changelog
### Breaking Changes
- Remove `Query.from_json`
- For `PluginTester.test_query`, switch from receiving a query object to taking kwargs that will be used to make a query object
### New Features
- `Query.update_results`
- `Query.update`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
