### PR TITLE
Make it easier to use builtin conditions

### DIFF
--- a/flogin/search_handler.py
+++ b/flogin/search_handler.py
@@ -36,6 +36,23 @@ LOG = logging.getLogger(__name__)
 
 __all__ = ("SearchHandler",)
 
+def builtin_condition_kwarg_to_obj(text: str = MISSING,
+        pattern: re.Pattern | str = MISSING,
+        keyword: str = MISSING,
+        allowed_keywords: Iterable[str] = MISSING,
+        disallowed_keywords: Iterable[str] = MISSING,):
+    if text is not MISSING:
+        return PlainTextCondition(text)
+    elif pattern is not MISSING:
+        if isinstance(pattern, str):
+            pattern = re.compile(pattern)
+        return RegexCondition(pattern)
+    elif keyword is not MISSING:
+        return KeywordCondition(allowed_keywords=[keyword])
+    elif allowed_keywords is not MISSING:
+        return KeywordCondition(allowed_keywords=allowed_keywords)
+    elif disallowed_keywords is not MISSING:
+        return KeywordCondition(disallowed_keywords=disallowed_keywords)
 
 class SearchHandler(Generic[PluginT]):
     r"""This represents a search handler.
@@ -57,9 +74,23 @@ class SearchHandler(Generic[PluginT]):
     def __init__(
         self,
         condition: SearchHandlerCondition | None = None,
+        *,
+        text: str = MISSING,
+        pattern: re.Pattern | str = MISSING,
+        keyword: str = MISSING,
+        allowed_keywords: Iterable[str] = MISSING,
+        disallowed_keywords: Iterable[str] = MISSING,
     ) -> None:
-        if condition is not None:
-            self.condition = condition  # type: ignore
+        if condition is None:
+            condition = builtin_condition_kwarg_to_obj(
+                text=text,
+                pattern=pattern,
+                keyword=keyword,
+                allowed_keywords=allowed_keywords,
+                disallowed_keywords=disallowed_keywords,
+            )
+        if condition:
+            self.condition = condition # type: ignore
 
         self.plugin: PluginT | None = None
 
@@ -72,21 +103,13 @@ class SearchHandler(Generic[PluginT]):
         allowed_keywords: Iterable[str] = MISSING,
         disallowed_keywords: Iterable[str] = MISSING,
     ) -> None:
-        con = None
-
-        if text is not MISSING:
-            con = PlainTextCondition(text)
-        elif pattern is not MISSING:
-            if isinstance(pattern, str):
-                pattern = re.compile(pattern)
-            con = RegexCondition(pattern)
-        elif keyword is not MISSING:
-            con = KeywordCondition(allowed_keywords=[keyword])
-        elif allowed_keywords is not MISSING:
-            con = KeywordCondition(allowed_keywords=allowed_keywords)
-        elif disallowed_keywords is not MISSING:
-            con = KeywordCondition(disallowed_keywords=disallowed_keywords)
-
+        con = builtin_condition_kwarg_to_obj(
+            text=text,
+            pattern=pattern,
+            keyword=keyword,
+            allowed_keywords=allowed_keywords,
+            disallowed_keywords=disallowed_keywords,
+        )
         if con is not None:
             cls.condition = con  # type: ignore
 

--- a/flogin/search_handler.py
+++ b/flogin/search_handler.py
@@ -10,6 +10,7 @@ from typing import (
     TypedDict,
     NotRequired,
     Iterable,
+    overload,
 )
 
 from ._types import PluginT, SearchHandlerCallbackReturns, SearchHandlerCondition
@@ -36,11 +37,14 @@ LOG = logging.getLogger(__name__)
 
 __all__ = ("SearchHandler",)
 
-def builtin_condition_kwarg_to_obj(text: str = MISSING,
-        pattern: re.Pattern | str = MISSING,
-        keyword: str = MISSING,
-        allowed_keywords: Iterable[str] = MISSING,
-        disallowed_keywords: Iterable[str] = MISSING,):
+
+def builtin_condition_kwarg_to_obj(
+    text: str = MISSING,
+    pattern: re.Pattern | str = MISSING,
+    keyword: str = MISSING,
+    allowed_keywords: Iterable[str] = MISSING,
+    disallowed_keywords: Iterable[str] = MISSING,
+):
     if text is not MISSING:
         return PlainTextCondition(text)
     elif pattern is not MISSING:
@@ -53,6 +57,7 @@ def builtin_condition_kwarg_to_obj(text: str = MISSING,
         return KeywordCondition(allowed_keywords=allowed_keywords)
     elif disallowed_keywords is not MISSING:
         return KeywordCondition(disallowed_keywords=disallowed_keywords)
+
 
 class SearchHandler(Generic[PluginT]):
     r"""This represents a search handler.
@@ -70,6 +75,40 @@ class SearchHandler(Generic[PluginT]):
     plugin: :class:`~flogin.plugin.Plugin` | None
         Your plugin instance. This is filled before :func:`~flogin.search_handler.SearchHandler.callback` is triggered.
     """
+
+    @overload
+    def __init__(self, condition: SearchHandlerCondition) -> None: ...
+
+    @overload
+    def __init__(self, *, text: str) -> None: ...
+
+    @overload
+    def __init__(
+        self,
+        *,
+        pattern: re.Pattern | str = MISSING,
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self,
+        *,
+        keyword: str = MISSING,
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self,
+        *,
+        allowed_keywords: Iterable[str] = MISSING,
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self,
+        *,
+        disallowed_keywords: Iterable[str] = MISSING,
+    ) -> None: ...
 
     def __init__(
         self,
@@ -90,9 +129,40 @@ class SearchHandler(Generic[PluginT]):
                 disallowed_keywords=disallowed_keywords,
             )
         if condition:
-            self.condition = condition # type: ignore
+            self.condition = condition  # type: ignore
 
         self.plugin: PluginT | None = None
+
+    @overload
+    def __init_subclass__(cls: type[SearchHandler], *, text: str) -> None: ...
+
+    @overload
+    def __init_subclass__(
+        cls: type[SearchHandler],
+        *,
+        pattern: re.Pattern | str = MISSING,
+    ) -> None: ...
+
+    @overload
+    def __init_subclass__(
+        cls: type[SearchHandler],
+        *,
+        keyword: str = MISSING,
+    ) -> None: ...
+
+    @overload
+    def __init_subclass__(
+        cls: type[SearchHandler],
+        *,
+        allowed_keywords: Iterable[str] = MISSING,
+    ) -> None: ...
+
+    @overload
+    def __init_subclass__(
+        cls: type[SearchHandler],
+        *,
+        disallowed_keywords: Iterable[str] = MISSING,
+    ) -> None: ...
 
     def __init_subclass__(
         cls: type[SearchHandler],

--- a/flogin/search_handler.py
+++ b/flogin/search_handler.py
@@ -38,27 +38,6 @@ LOG = logging.getLogger(__name__)
 __all__ = ("SearchHandler",)
 
 
-def builtin_condition_kwarg_to_obj(
-    text: str = MISSING,
-    pattern: re.Pattern | str = MISSING,
-    keyword: str = MISSING,
-    allowed_keywords: Iterable[str] = MISSING,
-    disallowed_keywords: Iterable[str] = MISSING,
-):
-    if text is not MISSING:
-        return PlainTextCondition(text)
-    elif pattern is not MISSING:
-        if isinstance(pattern, str):
-            pattern = re.compile(pattern)
-        return RegexCondition(pattern)
-    elif keyword is not MISSING:
-        return KeywordCondition(allowed_keywords=[keyword])
-    elif allowed_keywords is not MISSING:
-        return KeywordCondition(allowed_keywords=allowed_keywords)
-    elif disallowed_keywords is not MISSING:
-        return KeywordCondition(disallowed_keywords=disallowed_keywords)
-
-
 class SearchHandler(Generic[PluginT]):
     r"""This represents a search handler.
 
@@ -121,7 +100,7 @@ class SearchHandler(Generic[PluginT]):
         disallowed_keywords: Iterable[str] = MISSING,
     ) -> None:
         if condition is None:
-            condition = builtin_condition_kwarg_to_obj(
+            condition = self._builtin_condition_kwarg_to_obj(
                 text=text,
                 pattern=pattern,
                 keyword=keyword,
@@ -173,7 +152,7 @@ class SearchHandler(Generic[PluginT]):
         allowed_keywords: Iterable[str] = MISSING,
         disallowed_keywords: Iterable[str] = MISSING,
     ) -> None:
-        con = builtin_condition_kwarg_to_obj(
+        con = cls._builtin_condition_kwarg_to_obj(
             text=text,
             pattern=pattern,
             keyword=keyword,
@@ -182,6 +161,29 @@ class SearchHandler(Generic[PluginT]):
         )
         if con is not None:
             cls.condition = con  # type: ignore
+
+    @classmethod
+    def _builtin_condition_kwarg_to_obj(
+        cls: type[SearchHandler],
+        *,
+        text: str = MISSING,
+        pattern: re.Pattern | str = MISSING,
+        keyword: str = MISSING,
+        allowed_keywords: Iterable[str] = MISSING,
+        disallowed_keywords: Iterable[str] = MISSING,
+    ) -> SearchHandlerCondition | None:
+        if text is not MISSING:
+            return PlainTextCondition(text)
+        elif pattern is not MISSING:
+            if isinstance(pattern, str):
+                pattern = re.compile(pattern)
+            return RegexCondition(pattern)
+        elif keyword is not MISSING:
+            return KeywordCondition(allowed_keywords=[keyword])
+        elif allowed_keywords is not MISSING:
+            return KeywordCondition(allowed_keywords=allowed_keywords)
+        elif disallowed_keywords is not MISSING:
+            return KeywordCondition(disallowed_keywords=disallowed_keywords)
 
     def condition(self, query: Query) -> bool:
         r"""A function that determines whether or not to fire off this search handler for a given query


### PR DESCRIPTION
## Summary

Adds in a easier way to use builtin conditions for subclasses, and adds in support for quickly using more builtin conditions with the decorator.

## Changelog

### Breaking Changes

<!-- Any breaking changes? -->

### New Features

- Add `SearchHandler.__init_subclassed__`
- Add `keyword`, `allowed_keywords`, `text`, `patterns`, and `disallowed_keywords` kwargs to `Search.Handler__init__`
- Add `keyword`, `allowed_keywords`, and `disallowed_keywords` kwargs to `Plugin.search`

### Bug Fixes

<!-- Any bug fixes? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.