### PR TITLE
add flow env vars quickaccess attrs to plugin

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -160,6 +160,9 @@ Plugin Errors
 .. autoclass:: flogin.errors.PluginNotInitialized
     :members:
 
+.. autoclass:: flogin.errors.EnvNotSet
+    :members:
+
 JSON-RPC Errors
 ~~~~~~~~~~~~~~~
 

--- a/flogin/errors.py
+++ b/flogin/errors.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 __all__ = (
     "PluginException",
     "PluginNotInitialized",
+    "EnvNotSet"
 )
 
 
@@ -28,3 +29,20 @@ class InvalidContextDataReceived(ContextMenuHandlerException):
 
     def __init__(self):
         return super().__init__(f"Invalid context menu data received")
+
+class EnvNotSet(PluginException):
+    """This is raised when an environment variable that flow automatically sets is not set and can not be retrieved. This should only get raised when your plugin gets run, but not by flow.
+    
+    Attributes
+    -----------
+    name: :class:`str`
+        The name of the environment variable that was not found
+    alternative: Optional[:class:`str`]
+        Optionally, the name of the keyword argument in the :class:`~flogin.testing.plugin_tester.PluginTester` constructor that will set the variable for you.
+    """
+
+    def __init__(self, name: str, alternative: str | None = None) -> None:
+        self.name = name
+        self.alternative = alternative
+        alt = f"If you ran your plugin via the plugin tester, you can use the {alternative!r} keyword argument to quickly set this." if alternative else ""
+        super().__init__(f"The {name!r} environment variable is not set. These should be set by flow when it runs your plugin. {alt}")

--- a/flogin/errors.py
+++ b/flogin/errors.py
@@ -1,10 +1,6 @@
 from __future__ import annotations
 
-__all__ = (
-    "PluginException",
-    "PluginNotInitialized",
-    "EnvNotSet"
-)
+__all__ = ("PluginException", "PluginNotInitialized", "EnvNotSet")
 
 
 class PluginException(Exception):
@@ -30,11 +26,12 @@ class InvalidContextDataReceived(ContextMenuHandlerException):
     def __init__(self):
         return super().__init__(f"Invalid context menu data received")
 
+
 class EnvNotSet(PluginException):
     """This is raised when an environment variable that flow automatically sets is not set and can not be retrieved. This should only get raised when your plugin gets run, but not by flow.
 
     .. versionadded: 1.0.1
-    
+
     Attributes
     -----------
     name: :class:`str`
@@ -46,5 +43,11 @@ class EnvNotSet(PluginException):
     def __init__(self, name: str, alternative: str | None = None) -> None:
         self.name = name
         self.alternative = alternative
-        alt = f"If you ran your plugin via the plugin tester, you can use the {alternative!r} keyword argument to quickly set this." if alternative else ""
-        super().__init__(f"The {name!r} environment variable is not set. These should be set by flow when it runs your plugin. {alt}")
+        alt = (
+            f"If you ran your plugin via the plugin tester, you can use the {alternative!r} keyword argument to quickly set this."
+            if alternative
+            else ""
+        )
+        super().__init__(
+            f"The {name!r} environment variable is not set. These should be set by flow when it runs your plugin. {alt}"
+        )

--- a/flogin/errors.py
+++ b/flogin/errors.py
@@ -32,6 +32,8 @@ class InvalidContextDataReceived(ContextMenuHandlerException):
 
 class EnvNotSet(PluginException):
     """This is raised when an environment variable that flow automatically sets is not set and can not be retrieved. This should only get raised when your plugin gets run, but not by flow.
+
+    .. versionadded: 1.0.1
     
     Attributes
     -----------

--- a/flogin/plugin.py
+++ b/flogin/plugin.py
@@ -101,6 +101,11 @@ class Plugin(Generic[SettingsT]):
         """:class:`str`: the flow version from environment variables.
 
         .. versionadded:: 1.0.1
+
+        Raises
+        ------
+        :class:`~flogin.errors.EnvNotSet`
+            This is raised when the environment variable for this property is not set by flow or the plugin tester.
         """
 
         return self._get_env("FLOW_VERSION", "flow_version")
@@ -110,6 +115,11 @@ class Plugin(Generic[SettingsT]):
         """:class:`~pathlib.Path`: flow's application directory from environment variables.
 
         .. versionadded:: 1.0.1
+
+        Raises
+        ------
+        :class:`~flogin.errors.EnvNotSet`
+            This is raised when the environment variable for this property is not set by flow or the plugin tester.
         """
 
         return Path(self._get_env("FLOW_APPLICATION_DIRECTORY", "flow_application_dir"))
@@ -119,6 +129,11 @@ class Plugin(Generic[SettingsT]):
         """:class:`~pathlib.Path`: flow's application program from environment variables.
 
         .. versionadded:: 1.0.1
+
+        Raises
+        ------
+        :class:`~flogin.errors.EnvNotSet`
+            This is raised when the environment variable for this property is not set by flow or the plugin tester.
         """
 
         return Path(self._get_env("FLOW_PROGRAM_DIRECTORY", "flow_program_dir"))

--- a/flogin/plugin.py
+++ b/flogin/plugin.py
@@ -100,7 +100,9 @@ class Plugin(Generic[SettingsT]):
         try:
             return os.environ["FLOW_VERSION"]
         except KeyError:
-            raise RuntimeError(f"The 'FLOW_VERSION' environment variable is not set") from None
+            raise RuntimeError(
+                f"The 'FLOW_VERSION' environment variable is not set"
+            ) from None
 
     @cached_property
     def flow_application_directory(self) -> Path:
@@ -112,7 +114,9 @@ class Plugin(Generic[SettingsT]):
         try:
             return Path(os.environ["FLOW_APPLICATION_DIRECTORY"])
         except KeyError:
-            raise RuntimeError(f"The 'FLOW_APPLICATION_DIRECTORY' environment variable is not set") from None
+            raise RuntimeError(
+                f"The 'FLOW_APPLICATION_DIRECTORY' environment variable is not set"
+            ) from None
 
     @cached_property
     def flow_program_directory(self) -> Path:
@@ -124,7 +128,9 @@ class Plugin(Generic[SettingsT]):
         try:
             return Path(os.environ["FLOW_PROGRAM_DIRECTORY"])
         except KeyError:
-            raise RuntimeError(f"The 'FLOW_PROGRAM_DIRECTORY' environment variable is not set") from None
+            raise RuntimeError(
+                f"The 'FLOW_PROGRAM_DIRECTORY' environment variable is not set"
+            ) from None
 
     @cached_property
     def settings(self) -> SettingsT:

--- a/flogin/plugin.py
+++ b/flogin/plugin.py
@@ -20,7 +20,7 @@ from typing import (
 )
 
 from .default_events import get_default_events
-from .errors import InvalidContextDataReceived, PluginNotInitialized
+from .errors import InvalidContextDataReceived, PluginNotInitialized, EnvNotSet
 from .flow import FlowLauncherAPI, FlowSettings, PluginMetadata
 from .jsonrpc import (
     ErrorResponse,
@@ -90,6 +90,12 @@ class Plugin(Generic[SettingsT]):
         self.jsonrpc: JsonRPCClient = JsonRPCClient(self)
         self.api = FlowLauncherAPI(self.jsonrpc)
 
+    def _get_env(self, name: str, alternative: str | None = None) -> str:
+        try:
+            return os.environ[name]
+        except KeyError:
+            raise EnvNotSet(name, alternative)
+
     @cached_property
     def flow_version(self) -> str:
         """:class:`str`: the flow version from environment variables.
@@ -97,12 +103,7 @@ class Plugin(Generic[SettingsT]):
         .. versionadded:: 1.0.1
         """
 
-        try:
-            return os.environ["FLOW_VERSION"]
-        except KeyError:
-            raise RuntimeError(
-                f"The 'FLOW_VERSION' environment variable is not set"
-            ) from None
+        return self._get_env("FLOW_VERSION", "flow_version")
 
     @cached_property
     def flow_application_directory(self) -> Path:
@@ -111,12 +112,7 @@ class Plugin(Generic[SettingsT]):
         .. versionadded:: 1.0.1
         """
 
-        try:
-            return Path(os.environ["FLOW_APPLICATION_DIRECTORY"])
-        except KeyError:
-            raise RuntimeError(
-                f"The 'FLOW_APPLICATION_DIRECTORY' environment variable is not set"
-            ) from None
+        return Path(self._get_env("FLOW_APPLICATION_DIRECTORY", "flow_application_dir"))
 
     @cached_property
     def flow_program_directory(self) -> Path:
@@ -125,12 +121,7 @@ class Plugin(Generic[SettingsT]):
         .. versionadded:: 1.0.1
         """
 
-        try:
-            return Path(os.environ["FLOW_PROGRAM_DIRECTORY"])
-        except KeyError:
-            raise RuntimeError(
-                f"The 'FLOW_PROGRAM_DIRECTORY' environment variable is not set"
-            ) from None
+        return Path(self._get_env("FLOW_PROGRAM_DIRECTORY", "flow_program_dir"))
 
     @cached_property
     def settings(self) -> SettingsT:

--- a/flogin/plugin.py
+++ b/flogin/plugin.py
@@ -106,7 +106,7 @@ class Plugin(Generic[SettingsT]):
         return self._get_env("FLOW_VERSION", "flow_version")
 
     @cached_property
-    def flow_application_directory(self) -> Path:
+    def flow_application_dir(self) -> Path:
         """:class:`~pathlib.Path`: flow's application directory from environment variables.
 
         .. versionadded:: 1.0.1
@@ -115,7 +115,7 @@ class Plugin(Generic[SettingsT]):
         return Path(self._get_env("FLOW_APPLICATION_DIRECTORY", "flow_application_dir"))
 
     @cached_property
-    def flow_program_directory(self) -> Path:
+    def flow_program_dir(self) -> Path:
         """:class:`~pathlib.Path`: flow's application program from environment variables.
 
         .. versionadded:: 1.0.1

--- a/flogin/plugin.py
+++ b/flogin/plugin.py
@@ -92,30 +92,39 @@ class Plugin(Generic[SettingsT]):
 
     @cached_property
     def flow_version(self) -> str:
-        """:class:`str`: the flow version from enviroment variables.
+        """:class:`str`: the flow version from environment variables.
 
         .. versionadded:: 1.0.1
         """
 
-        return os.environ["FLOW_VERSION"]
+        try:
+            return os.environ["FLOW_VERSION"]
+        except KeyError:
+            raise RuntimeError(f"The 'FLOW_VERSION' environment variable is not set") from None
 
     @cached_property
     def flow_application_directory(self) -> Path:
-        """:class:`~pathlib.Path`: flow's application directory from enviroment variables.
+        """:class:`~pathlib.Path`: flow's application directory from environment variables.
 
         .. versionadded:: 1.0.1
         """
 
-        return Path(os.environ["FLOW_APPLICATION_DIRECTORY"])
+        try:
+            return Path(os.environ["FLOW_APPLICATION_DIRECTORY"])
+        except KeyError:
+            raise RuntimeError(f"The 'FLOW_APPLICATION_DIRECTORY' environment variable is not set") from None
 
     @cached_property
     def flow_program_directory(self) -> Path:
-        """:class:`~pathlib.Path`: flow's application program from enviroment variables.
+        """:class:`~pathlib.Path`: flow's application program from environment variables.
 
         .. versionadded:: 1.0.1
         """
 
-        return Path(os.environ["FLOW_PROGRAM_DIRECTORY"])
+        try:
+            return Path(os.environ["FLOW_PROGRAM_DIRECTORY"])
+        except KeyError:
+            raise RuntimeError(f"The 'FLOW_PROGRAM_DIRECTORY' environment variable is not set") from None
 
     @cached_property
     def settings(self) -> SettingsT:

--- a/flogin/plugin.py
+++ b/flogin/plugin.py
@@ -29,6 +29,7 @@ from .jsonrpc import (
     QueryResponse,
     Result,
 )
+from pathlib import Path
 from .jsonrpc.responses import BaseResponse
 from .query import Query
 from .search_handler import SearchHandler
@@ -88,6 +89,33 @@ class Plugin(Generic[SettingsT]):
         )
         self.jsonrpc: JsonRPCClient = JsonRPCClient(self)
         self.api = FlowLauncherAPI(self.jsonrpc)
+
+    @cached_property
+    def flow_version(self) -> str:
+        """:class:`str`: the flow version from enviroment variables.
+
+        .. versionadded:: 1.0.1
+        """
+
+        return os.environ["FLOW_VERSION"]
+
+    @cached_property
+    def flow_application_directory(self) -> Path:
+        """:class:`~pathlib.Path`: flow's application directory from enviroment variables.
+
+        .. versionadded:: 1.0.1
+        """
+
+        return Path(os.environ["FLOW_APPLICATION_DIRECTORY"])
+
+    @cached_property
+    def flow_program_directory(self) -> Path:
+        """:class:`~pathlib.Path`: flow's application program from enviroment variables.
+
+        .. versionadded:: 1.0.1
+        """
+
+        return Path(os.environ["FLOW_PROGRAM_DIRECTORY"])
 
     @cached_property
     def settings(self) -> SettingsT:

--- a/flogin/plugin.py
+++ b/flogin/plugin.py
@@ -94,7 +94,7 @@ class Plugin(Generic[SettingsT]):
         try:
             return os.environ[name]
         except KeyError:
-            raise EnvNotSet(name, alternative)
+            raise EnvNotSet(name, alternative) from None
 
     @cached_property
     def flow_version(self) -> str:

--- a/flogin/testing/plugin_tester.py
+++ b/flogin/testing/plugin_tester.py
@@ -42,11 +42,17 @@ class PluginTester(Generic[PluginT]):
         If not passed, flogin will use a filler class which will raise a runtime error whenever an attribute is accessed. If passed, you should be passing an instance of a class which will replace :class:`~flogin.flow.api.FlowLauncherAPI`, so make sure to implement the methods you need and handle them accordingly.
     flow_version: Optional[:class:`str`]
         This is an optional positional keyword that if set, will automatically set the enviroment variable ``FLOW_VERSION`` to the value. This is useful if your code uses the :attr:`~flogin.plugin.Plugin.flow_version` property.
+    
+        .. versionadded: 1.0.1
     flow_application_dir: Optional[:class:`str` | :class:`~pathlib.Path`]
         This is an optional positional keyword that if set, will automatically set the enviroment variable ``FLOW_APPLICATION_DIRECTORY`` to the value. This is useful if your code uses the :attr:`~flogin.plugin.Plugin.flow_application_dir` property.
+
+        .. versionadded: 1.0.1
     flow_program_dir: Optional[:class:`str` | :class:`~pathlib.Path`]
         This is an optional positional keyword that if set, will automatically set the enviroment variable ``FLOW_PROGRAM_DIRECTORY`` to the value. This is useful if your code uses the :attr:`~flogin.plugin.Plugin.flow_program_dir` property.
 
+        .. versionadded: 1.0.1
+        
     Attributes
     ----------
     plugin: :class:`~flogin.plugin.Plugin`

--- a/flogin/testing/plugin_tester.py
+++ b/flogin/testing/plugin_tester.py
@@ -4,6 +4,7 @@ import json
 import os
 import random
 import sys
+from pathlib import Path
 import uuid
 from typing import TYPE_CHECKING, Any, Generic
 
@@ -39,6 +40,12 @@ class PluginTester(Generic[PluginT]):
         Your plugin's metadata. If ``None`` is passed, flogin will attempt to get the metadata from your ``plugin.json`` file. The :func:`PluginTester.create_plugin_metadata` and :func:`PluginTester.create_bogus_plugin_metadata` classmethods have been provided for creating :class:`~flogin.flow.plugin_metadata.PluginMetadata` objects.
     flow_api_client: Optional[Any]
         If not passed, flogin will use a filler class which will raise a runtime error whenever an attribute is accessed. If passed, you should be passing an instance of a class which will replace :class:`~flogin.flow.api.FlowLauncherAPI`, so make sure to implement the methods you need and handle them accordingly.
+    flow_version: Optional[:class:`str`]
+        This is an optional positional keyword that if set, will automatically set the enviroment variable ``FLOW_VERSION`` to the value. This is useful if your code uses the :attr:`~flogin.plugin.Plugin.flow_version` property.
+    flow_application_dir: Optional[:class:`str` | :class:`~pathlib.Path`]
+        This is an optional positional keyword that if set, will automatically set the enviroment variable ``FLOW_APPLICATION_DIRECTORY`` to the value. This is useful if your code uses the :attr:`~flogin.plugin.Plugin.flow_application_dir` property.
+    flow_program_dir: Optional[:class:`str` | :class:`~pathlib.Path`]
+        This is an optional positional keyword that if set, will automatically set the enviroment variable ``FLOW_PROGRAM_DIRECTORY`` to the value. This is useful if your code uses the :attr:`~flogin.plugin.Plugin.flow_program_dir` property.
 
     Attributes
     ----------
@@ -54,6 +61,9 @@ class PluginTester(Generic[PluginT]):
         *,
         metadata: PluginMetadata | dict[str, Any] | None,
         flow_api_client: Any = MISSING,
+        flow_version: str = MISSING,
+        flow_application_dir: Path | str = MISSING,
+        flow_program_dir: Path | str = MISSING,
     ) -> None:
         self.plugin = plugin
 
@@ -72,6 +82,14 @@ class PluginTester(Generic[PluginT]):
         self.plugin._metadata = metadata
 
         self.set_flow_api_client(flow_api_client)
+
+        if flow_version is not None:
+            os.environ["FLOW_VERSION"] = flow_version
+        if flow_application_dir is not None:
+            os.environ["FLOW_APPLICATION_DIRECTORY"] = str(flow_application_dir)
+        if flow_program_dir is not None:
+            os.environ["FLOW_PROGRAM_DIRECTORY"] = str(flow_program_dir)
+
 
     def set_flow_api_client(self, flow_api_client: Any = MISSING) -> None:
         r"""This sets the flow api client that the tests should use.

--- a/flogin/testing/plugin_tester.py
+++ b/flogin/testing/plugin_tester.py
@@ -89,11 +89,11 @@ class PluginTester(Generic[PluginT]):
 
         self.set_flow_api_client(flow_api_client)
 
-        if flow_version is not None:
+        if flow_version is not MISSING:
             os.environ["FLOW_VERSION"] = flow_version
-        if flow_application_dir is not None:
+        if flow_application_dir is not MISSING:
             os.environ["FLOW_APPLICATION_DIRECTORY"] = str(flow_application_dir)
-        if flow_program_dir is not None:
+        if flow_program_dir is not MISSING:
             os.environ["FLOW_PROGRAM_DIRECTORY"] = str(flow_program_dir)
 
     def set_flow_api_client(self, flow_api_client: Any = MISSING) -> None:

--- a/flogin/testing/plugin_tester.py
+++ b/flogin/testing/plugin_tester.py
@@ -42,7 +42,7 @@ class PluginTester(Generic[PluginT]):
         If not passed, flogin will use a filler class which will raise a runtime error whenever an attribute is accessed. If passed, you should be passing an instance of a class which will replace :class:`~flogin.flow.api.FlowLauncherAPI`, so make sure to implement the methods you need and handle them accordingly.
     flow_version: Optional[:class:`str`]
         This is an optional positional keyword that if set, will automatically set the enviroment variable ``FLOW_VERSION`` to the value. This is useful if your code uses the :attr:`~flogin.plugin.Plugin.flow_version` property.
-    
+
         .. versionadded: 1.0.1
     flow_application_dir: Optional[:class:`str` | :class:`~pathlib.Path`]
         This is an optional positional keyword that if set, will automatically set the enviroment variable ``FLOW_APPLICATION_DIRECTORY`` to the value. This is useful if your code uses the :attr:`~flogin.plugin.Plugin.flow_application_dir` property.
@@ -52,7 +52,7 @@ class PluginTester(Generic[PluginT]):
         This is an optional positional keyword that if set, will automatically set the enviroment variable ``FLOW_PROGRAM_DIRECTORY`` to the value. This is useful if your code uses the :attr:`~flogin.plugin.Plugin.flow_program_dir` property.
 
         .. versionadded: 1.0.1
-        
+
     Attributes
     ----------
     plugin: :class:`~flogin.plugin.Plugin`
@@ -95,7 +95,6 @@ class PluginTester(Generic[PluginT]):
             os.environ["FLOW_APPLICATION_DIRECTORY"] = str(flow_application_dir)
         if flow_program_dir is not None:
             os.environ["FLOW_PROGRAM_DIRECTORY"] = str(flow_program_dir)
-
 
     def set_flow_api_client(self, flow_api_client: Any = MISSING) -> None:
         r"""This sets the flow api client that the tests should use.


### PR DESCRIPTION
## Summary

add flow env vars quickaccess attrs to plugin

## Changelog

### Breaking Changes

<!-- Any breaking changes? -->

### New Features

- Add `Plugin.flow_version`
- Add `Plugin.flow_application_directory`
- Add `Plugin.flow_program_directory`

### Bug Fixes

<!-- Any bug fixes? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added cached properties to retrieve flow-related environment variables, including flow version, application directory, and program directory.
	- Introduced a new exception for handling missing environment variables.
	- Enhanced the `PluginTester` class to accept optional parameters for flow-related environment variables during instantiation.
	- Updated documentation to include the new `EnvNotSet` exception in the API reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->