### PR TITLE
add version guarantees to docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3,6 +3,25 @@
 API Reference
 =============
 
+The following section outlines the API of flogin.
+
+Version Related Info
+---------------------
+
+There are two main ways to query version information about the library. For guarantees, check :ref:`version_guarantees`.
+
+.. data:: version_info
+
+    A named tuple that is similar to :obj:`sys.version_info`.
+
+    Just like :obj:`sys.version_info` the valid values for ``releaselevel`` are
+    'alpha', 'beta', 'candidate' and 'final'.
+
+.. data:: __version__
+
+    A string representation of the version. e.g. ``'1.0.0rc1'``. This is based
+    off of :pep:`440`.
+
 Plugin
 ------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,3 +58,4 @@ If you're having trouble with something, these resources might help.
    search_handlers
    whats_new
    testing
+   version_guarantees

--- a/docs/version_guarantees.rst
+++ b/docs/version_guarantees.rst
@@ -1,0 +1,32 @@
+.. _version_guarantees:
+
+Version Guarantees
+=====================
+
+The library follows a `semantic versioning principle <https://semver.org/>`_ which means that the major version is updated every time there is an incompatible API change. However, due to the impulsiveness of the dev, it can be hard to determine what is a breaking change and what isn't.
+
+The first thing to keep in mind is that breaking changes only apply to things that are **publicly documented**. If it's not listed in the documentation here then it is not part of the public API and is thus bound to change. This includes attributes that start with an underscore or functions without an underscore that are not documented.
+
+.. note::
+
+    The examples below are non-exhaustive.
+
+Examples of Breaking Changes
+------------------------------
+
+- Changing the default parameter value to something else.
+- Renaming a function without an alias to an old function.
+- Adding or removing parameters to an event.
+
+Examples of Non-Breaking Changes
+----------------------------------
+
+- Adding or removing private underscored attributes.
+- Adding an element into the ``__slots__`` of a data class.
+- Changing the behaviour of a function to fix a bug.
+- Changes in the typing behaviour of the library
+- Changes in the calling convention of functions that are primarily meant as callbacks
+- Changes in the documentation.
+- Modifying the internal HTTP handling.
+- Upgrading the dependencies to a new version, major or otherwise.
+


### PR DESCRIPTION
## Summary

Adds version guarantees and info to the docs

## Changelog

### Breaking Changes

<!-- Any breaking changes? -->

### New Features

<!-- Any new features? -->

### Bug Fixes

<!-- Any bug fixes? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added new documentation sections:
    - Version Related Info in API documentation
    - Version Guarantees section explaining semantic versioning principles
  - Included details about version information retrieval methods
  - Clarified library's approach to versioning and API changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->