### PR TITLE
+ decorator decorator for optional ability to use as classmethod + is_factory for docs

### DIFF
--- a/docs/_static/custom.js
+++ b/docs/_static/custom.js
@@ -28,8 +28,7 @@ document.addEventListener('DOMContentLoaded', () => {
             params[0].remove();
             console.log(`Remove`, params[0]);
             let parens = el.getElementsByClassName("sig-paren");
-            if (parens){
-                parens[0].remove();
+            while (parens.length > 0) {
                 parens[0].remove();
             }
         }

--- a/docs/_static/custom.js
+++ b/docs/_static/custom.js
@@ -18,10 +18,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
         span.innerHTML = `@${span.innerHTML}`;
         console.log(`Decorator: ${name}`);
+
+        let isFac = decoBadge.dataset['isfactory']
+
+        console.log(`isFac`, isFac)
         
-        // This removes the parens from any deco with a single param. Will probably need to eventually update
-        let params = el.getElementsByClassName("sig-param");
-        if (params.length === 1){
+        if (isFac === "False"){
+            let params = el.getElementsByClassName("sig-param");
             params[0].remove();
             console.log(`Remove`, params[0]);
             let parens = el.getElementsByClassName("sig-paren");

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,7 +51,7 @@ extensions = [
     "sphinx.ext.intersphinx",  # https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
     "sphinx_toolbox.more_autodoc.typevars",  # https://sphinx-toolbox.readthedocs.io/en/latest/extensions/more_autodoc/typevars.html
     "sphinxcontrib_trio",  # https://sphinxcontrib-trio.readthedocs.io/en/latest/
-    "sphinx_copybutton", # https://github.com/executablebooks/sphinx-copybutton#readme
+    "sphinx_copybutton",  # https://github.com/executablebooks/sphinx-copybutton#readme
     "nitpick_file_ignorer",
     "attributetable",
 ]

--- a/flogin/plugin.py
+++ b/flogin/plugin.py
@@ -35,7 +35,13 @@ from .jsonrpc.responses import BaseResponse
 from .query import Query
 from .search_handler import SearchHandler
 from .settings import Settings
-from .utils import MISSING, cached_property, coro_or_gen, setup_logging, InstanceAndClassDecorator
+from .utils import (
+    MISSING,
+    cached_property,
+    coro_or_gen,
+    setup_logging,
+    InstanceAndClassDecorator,
+)
 
 if TYPE_CHECKING:
     from typing_extensions import TypeVar
@@ -405,11 +411,11 @@ class Plugin(Generic[SettingsT]):
 
         self.register_event(callback)
         return callback
-    
+
     @event.classmethod
     @classmethod
     def __event_classmethod_deco(cls, callback: EventCallbackT) -> EventCallbackT:
-        #setattr(callback, "__flogin_add_as_event__", True)
+        # setattr(callback, "__flogin_add_as_event__", True)
         cls.__class_events__.append(callback.__name__)
         return callback
 

--- a/flogin/plugin.py
+++ b/flogin/plugin.py
@@ -18,7 +18,6 @@ from typing import (
     TypeVarTuple,
     overload,
 )
-import inspect
 
 from .default_events import get_default_events
 from .errors import PluginNotInitialized, EnvNotSet
@@ -40,7 +39,7 @@ from .utils import (
     cached_property,
     coro_or_gen,
     setup_logging,
-    InstanceAndClassDecorator,
+    decorator,
 )
 
 if TYPE_CHECKING:
@@ -389,7 +388,7 @@ class Plugin(Generic[SettingsT]):
 
         self._events[name or callback.__name__] = callback
 
-    @InstanceAndClassDecorator
+    @decorator(is_factory=False)
     def event(self, callback: EventCallbackT) -> EventCallbackT:
         """A decorator that registers an event to listen for.
 

--- a/flogin/plugin.py
+++ b/flogin/plugin.py
@@ -18,6 +18,7 @@ from typing import (
     TypeVarTuple,
     overload,
 )
+import inspect
 
 from .default_events import get_default_events
 from .errors import PluginNotInitialized, EnvNotSet
@@ -34,7 +35,7 @@ from .jsonrpc.responses import BaseResponse
 from .query import Query
 from .search_handler import SearchHandler
 from .settings import Settings
-from .utils import MISSING, cached_property, coro_or_gen, setup_logging
+from .utils import MISSING, cached_property, coro_or_gen, setup_logging, InstanceAndClassDecorator
 
 if TYPE_CHECKING:
     from typing_extensions import TypeVar
@@ -67,6 +68,8 @@ class Plugin(Generic[SettingsT]):
         Whether or not to ignore cancellation requests sent from flow. Defaults to ``False``
     """
 
+    __class_events__: list[str] = []
+
     def __init__(self, **options: Any) -> None:
         self.options = options
         self._metadata: PluginMetadata | None = None
@@ -79,6 +82,11 @@ class Plugin(Generic[SettingsT]):
             self
         )
         self.jsonrpc: JsonRPCClient = JsonRPCClient(self)
+
+        # for event_name, event_callback in inspect.getmembers(self, lambda x: getattr(x, "__flogin_add_as_event__", False)):
+        #     self.register_event(event_callback, event_name)
+        for event_name in self.__class_events__:
+            self.register_event(getattr(self, event_name))
 
     @property
     def last_query(self) -> Query | None:
@@ -375,6 +383,7 @@ class Plugin(Generic[SettingsT]):
 
         self._events[name or callback.__name__] = callback
 
+    @InstanceAndClassDecorator
     def event(self, callback: EventCallbackT) -> EventCallbackT:
         """A decorator that registers an event to listen for.
 
@@ -395,6 +404,13 @@ class Plugin(Generic[SettingsT]):
         """
 
         self.register_event(callback)
+        return callback
+    
+    @event.classmethod
+    @classmethod
+    def __event_classmethod_deco(cls, callback: EventCallbackT) -> EventCallbackT:
+        #setattr(callback, "__flogin_add_as_event__", True)
+        cls.__class_events__.append(callback.__name__)
         return callback
 
     @overload

--- a/flogin/search_handler.py
+++ b/flogin/search_handler.py
@@ -19,6 +19,7 @@ from .conditions import (
     PlainTextCondition,
 )
 import re
+from .utils import decorator
 
 if TYPE_CHECKING:
     from .query import Query
@@ -290,6 +291,7 @@ class SearchHandler(Generic[PluginT]):
         """:class:`str`: The name of the search handler's callback"""
         return self.callback.__name__
 
+    @decorator(is_factory=False)
     def error(self, func: ErrorHandlerT) -> ErrorHandlerT:
         """A decorator that registers a error handler for this search handler.
 

--- a/flogin/utils.py
+++ b/flogin/utils.py
@@ -12,6 +12,7 @@ from typing import (
     Coroutine,
     TypeVar,
     Self,
+    Generic,
 )
 from typing import NamedTuple, Literal
 from typing import overload
@@ -189,7 +190,7 @@ class VersionInfo(NamedTuple):
         return cls(major=major, minor=minor, micro=micro, releaselevel=release_level)
 
 
-class decorator[OwnerT, FuncT, ReturnT]:
+class decorator(Generic[OwnerT, FuncT, ReturnT]):
     @overload
     def __init__(self, /, *, is_factory: bool = True) -> None: ...
     @overload
@@ -241,7 +242,7 @@ class decorator[OwnerT, FuncT, ReturnT]:
 
         return wrapper
 
-    def classmethod[T](self, func: T) -> T:
+    def classmethod(self, func: T) -> T:
         if isinstance(func, classmethod):
             func = func.__func__
         self.__classmethod_func__ = func  # type: ignore


### PR DESCRIPTION
## Summary

Adds a new `utils.decorator` class for making decorators. The deco class lets decorators support classmethods, and has an `is_factory` option which is now used with the docs to determine if a decorator is a factory or not

This also fixes #34

## Changelog

### Breaking Changes

<!-- Any breaking changes? -->

### New Features

- undocumented `utils.decorator`
- Ability to use `Plugin.event` as a classmethod

### Bug Fixes

<!-- Any bug fixes? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced decorator functionality across the project.
	- Improved error handling in search functionality.
	- Added more flexible event registration mechanism for plugins.

- **Documentation**
	- Updated Sphinx documentation configuration.
	- Refined attribute table generation for documentation.

- **Chores**
	- Minor formatting improvements in configuration files.
	- Added type safety enhancements to utility functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->