### PR TITLE
add utils.print

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -302,6 +302,8 @@ Utils
 
 .. autofunction:: flogin.utils.coro_or_gen
 
+.. autofunction:: flogin.utils.print
+
 .. attribute:: flogin.utils.MISSING
 
     A type safe sentinel used in the library to represent something as missing. Used to distinguish from ``None`` values.

--- a/flogin/plugin.py
+++ b/flogin/plugin.py
@@ -384,7 +384,7 @@ class Plugin(Generic[SettingsT]):
 
     @decorator(is_factory=False)
     def event(self, callback: EventCallbackT) -> EventCallbackT:
-        """A decorator that registers an event to listen for.
+        """A decorator that registers an event to listen for. This decorator can be used with a plugin instance or as a classmethod.
 
         All events must be a :ref:`coroutine <coroutine>`.
 
@@ -394,12 +394,22 @@ class Plugin(Generic[SettingsT]):
         Example
         ---------
 
+        With a plugin instance:
+
         .. code-block:: python3
 
             @plugin.event
             async def on_initialization():
                 print('Ready!')
 
+        As a classmethod:
+
+        .. code-block:: python3
+
+            class MyPlugin(Plugin):
+                @Plugin.event
+                async def on_initialization(self):
+                    print('Ready!')
         """
 
         self.register_event(callback)

--- a/flogin/utils.py
+++ b/flogin/utils.py
@@ -29,7 +29,7 @@ ClassMethodT = Callable[[type[OwnerT], FuncT], ReturnT]
 InstanceMethodT = Callable[[OwnerT, FuncT], ReturnT]
 
 LOG = logging.getLogger(__name__)
-
+_print_log = logging.getLogger("printing")
 
 class _cached_property:
     def __init__(self, function) -> None:
@@ -45,7 +45,6 @@ class _cached_property:
 
         return value
 
-
 if TYPE_CHECKING:
     from functools import cached_property as cached_property
 else:
@@ -55,6 +54,7 @@ __all__ = (
     "setup_logging",
     "coro_or_gen",
     "MISSING",
+    "print"
 )
 
 
@@ -251,3 +251,21 @@ class decorator(Generic[OwnerT, FuncT, ReturnT]):
             func = func.__func__
         self.__classmethod_func__ = func  # type: ignore
         return func
+ 
+def print(*values: object, sep: str = MISSING) -> None:
+    r"""A function that acts similar to :func:`builtins.print`, but uses the `logging <https://docs.python.org/3/library/logging.html#module-logging>`__ module instead.
+    
+    This helper function is provided to easily "print" text without having to setup a logging object, because the builtin print function does not work as expected due to the jsonrpc pipes.
+    
+    Parameters
+    -----------
+    \*values: :class:`object`
+        A list of values to print
+    sep: Optional[:class:`str`]
+        The character that is used as the seperator between the values. Defaults to `` ``
+    """
+
+    if sep is MISSING:
+        sep = " "
+
+    _print_log.info(sep.join([str(val) for val in values]))

--- a/flogin/utils.py
+++ b/flogin/utils.py
@@ -253,7 +253,7 @@ class decorator(Generic[OwnerT, FuncT, ReturnT]):
         return func
  
 def print(*values: object, sep: str = MISSING) -> None:
-    r"""A function that acts similar to :func:`builtins.print`, but uses the `logging <https://docs.python.org/3/library/logging.html#module-logging>`__ module instead.
+    r"""A function that acts similar to the `builtin print function <https://docs.python.org/3/library/functions.html#print>`__, but uses the `logging <https://docs.python.org/3/library/logging.html#module-logging>`__ module instead.
     
     This helper function is provided to easily "print" text without having to setup a logging object, because the builtin print function does not work as expected due to the jsonrpc pipes.
     
@@ -262,7 +262,7 @@ def print(*values: object, sep: str = MISSING) -> None:
     \*values: :class:`object`
         A list of values to print
     sep: Optional[:class:`str`]
-        The character that is used as the seperator between the values. Defaults to `` ``
+        The character that is used as the seperator between the values. Defaults to a space.
     """
 
     if sep is MISSING:

--- a/flogin/utils.py
+++ b/flogin/utils.py
@@ -266,4 +266,4 @@ def print(*values: object, sep: str = MISSING) -> None:
     if sep is MISSING:
         sep = " "
 
-    _print_log.info(sep.join([str(val) for val in values]))
+    _print_log.info(sep.join(str(val) for val in values))

--- a/flogin/utils.py
+++ b/flogin/utils.py
@@ -255,6 +255,9 @@ def print(*values: object, sep: str = MISSING) -> None:
 
     This helper function is provided to easily "print" text without having to setup a logging object, because the builtin print function does not work as expected due to the jsonrpc pipes.
 
+    .. NOTE::
+        The log/print statements can be viewed in your ``flogin.log`` file under the name ``printing``
+
     Parameters
     -----------
     \*values: :class:`object`

--- a/flogin/utils.py
+++ b/flogin/utils.py
@@ -31,6 +31,7 @@ InstanceMethodT = Callable[[OwnerT, FuncT], ReturnT]
 LOG = logging.getLogger(__name__)
 _print_log = logging.getLogger("printing")
 
+
 class _cached_property:
     def __init__(self, function) -> None:
         self.function = function
@@ -45,17 +46,13 @@ class _cached_property:
 
         return value
 
+
 if TYPE_CHECKING:
     from functools import cached_property as cached_property
 else:
     cached_property = _cached_property
 
-__all__ = (
-    "setup_logging",
-    "coro_or_gen",
-    "MISSING",
-    "print"
-)
+__all__ = ("setup_logging", "coro_or_gen", "MISSING", "print")
 
 
 def copy_doc(original: Callable[..., Any]) -> Callable[[T], T]:
@@ -251,12 +248,13 @@ class decorator(Generic[OwnerT, FuncT, ReturnT]):
             func = func.__func__
         self.__classmethod_func__ = func  # type: ignore
         return func
- 
+
+
 def print(*values: object, sep: str = MISSING) -> None:
     r"""A function that acts similar to the `builtin print function <https://docs.python.org/3/library/functions.html#print>`__, but uses the `logging <https://docs.python.org/3/library/logging.html#module-logging>`__ module instead.
-    
+
     This helper function is provided to easily "print" text without having to setup a logging object, because the builtin print function does not work as expected due to the jsonrpc pipes.
-    
+
     Parameters
     -----------
     \*values: :class:`object`


### PR DESCRIPTION
## Summary

"This helper function is provided to easily "print" text without having to setup a logging object, because the builtin print function does not work as expected due to the jsonrpc pipes."

## Changelog

### Breaking Changes

<!-- Any breaking changes? -->

### New Features

- Add `flogin.utils.print`

### Bug Fixes

<!-- Any bug fixes? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Enhanced documentation for the `event` decorator in the `Plugin` class with usage examples.
	- Added API reference for the `print` function in the `flogin.utils` module.

- **New Features**
	- Introduced a new logging-based `print` function in the `utils` module that provides an alternative to the built-in `print` function.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->