### PR TITLE
44 allow result templates to return boolnone

### DIFF
--- a/flogin/jsonrpc/client.py
+++ b/flogin/jsonrpc/client.py
@@ -111,20 +111,11 @@ class JsonRPCClient:
         method: str = request["method"]
         params: list[Any] = request["params"]
         task = None
-        error_handler = "on_error"
 
         self.request_id = request["id"]
 
         if method.startswith("flogin.action"):
-            slug = method.removeprefix("flogin.action.")
-            result = self.plugin._results.get(slug)
-            if result:
-                callback = result.callback
-                error_handler = result.on_error
-                result.plugin = self.plugin
-                task = self.plugin._schedule_event(
-                    callback, method, error_handler=error_handler
-                )
+            task = self.plugin.process_action(method)
 
         if task is None:
             task = self.plugin.dispatch(method, *params)

--- a/flogin/jsonrpc/results.py
+++ b/flogin/jsonrpc/results.py
@@ -239,15 +239,18 @@ class Result(Base, Generic[PluginT]):
         )
         return ErrorResponse.internal_error(error)
 
-    async def callback(self) -> ExecuteResponse:
+    async def callback(self) -> ExecuteResponse | bool | None:
         r"""|coro|
 
         Override this function to add a callback behavior to your result. This method will run when the user clicks on your result.
 
+        .. versionchanged:: 2.0.0
+            A result callback can not return :class:`bool` or ``None``
+
         Returns
         -------
-        :class:`~flogin.jsonrpc.responses.ExecuteResponse`
-            A response to flow determining whether or not to hide flow's menu
+        :class:`~flogin.jsonrpc.responses.ExecuteResponse` | :class:`bool` | ``None``
+            A response to flow determining whether or not to hide flow's menu, or a bool that will be turned into a response. ``None`` will be converted into ``True`` to align with the default value for :attr:`~flogin.jsonrpc.responses.ExecuteResponse.hide`
         """
 
         return ExecuteResponse(False)

--- a/flogin/plugin.py
+++ b/flogin/plugin.py
@@ -321,7 +321,10 @@ class Plugin(Generic[SettingsT]):
 
         result.plugin = self
         return self._schedule_event(
-            self._action_callback_wrapper, method, args=[result.callback], error_handler=result.on_error
+            self._action_callback_wrapper,
+            method,
+            args=[result.callback],
+            error_handler=result.on_error,
         )
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ ignore = [
     "E501", # https://docs.astral.sh/ruff/rules/#error-e_1
     "ANN401", # https://docs.astral.sh/ruff/rules/any-type/
     "RET503", # https://docs.astral.sh/ruff/rules/implicit-return/
+    "RET502", # https://docs.astral.sh/ruff/rules/implicit-return-value/
 ]
 
 [tool.ruff.format]


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Changelog

### Breaking Changes

<!-- Any breaking changes? -->

### New Features

<!-- Any new features? -->

### Bug Fixes

<!-- Any bug fixes? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced action processing capabilities in the JSON-RPC client
  - Expanded callback method to support more flexible return types

- **Improvements**
  - Simplified request handling in the JSON-RPC client
  - Improved error handling and logging mechanisms

- **Documentation**
  - Updated method documentation with clearer return type descriptions
  - Corrected minor typos in error logging

- **Chores**
  - Updated linter configuration to ignore specific rule

<!-- end of auto-generated comment: release notes by coderabbit.ai -->