### PR TITLE
defer formatting logs

### DIFF
--- a/flogin/caching.py
+++ b/flogin/caching.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import logging
-import logging.handlers
 from collections import defaultdict
 from collections.abc import AsyncGenerator, Awaitable, Callable, Coroutine
 from functools import _make_key as make_cached_key
@@ -21,8 +19,6 @@ from .utils import MISSING, coro_or_gen
 Coro = TypeVar("Coro", bound=Callable[..., Coroutine[Any, Any, Any]])
 AGenT = TypeVar("AGenT", bound=Callable[..., AsyncGenerator[Any, Any]])
 T = TypeVar("T")
-
-LOG = logging.getLogger(__name__)
 
 __all__ = (
     "cached_callable",

--- a/flogin/default_events.py
+++ b/flogin/default_events.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from .plugin import Plugin
 
 
-LOG = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 __all__ = ("on_error",)
 
@@ -22,7 +22,7 @@ async def on_error(
     event_method: str, error: Exception, *args: Any, **kwargs: Any
 ) -> ErrorResponse:
     """gets called when an error occurs in an event"""
-    LOG.exception(f"Ignoring exception in event {event_method!r}", exc_info=error)
+    log.exception("Ignoring exception in event %r", event_method, exc_info=error)
     return ErrorResponse.internal_error(error)
 
 
@@ -35,7 +35,7 @@ def get_default_events(plugin: Plugin[Any]) -> dict[str, Callable[..., Awaitable
         plugin._results.clear()
 
         if plugin._settings_are_populated is False:
-            LOG.info("Settings have not been populated yet, creating a new instance")
+            log.info("Settings have not been populated yet, creating a new instance")
             plugin._settings_are_populated = True
             plugin.settings = Settings(
                 raw_settings, no_update=plugin.options.get("settings_no_update", False)

--- a/flogin/jsonrpc/client.py
+++ b/flogin/jsonrpc/client.py
@@ -84,7 +84,7 @@ class JsonRPCClient:
             except asyncio.InvalidStateError:
                 pass
         else:
-            log.exception(
+            log.error(
                 "Result from unknown request given. id=%r, result=%r", rid, result
             )
 

--- a/flogin/jsonrpc/client.py
+++ b/flogin/jsonrpc/client.py
@@ -15,7 +15,7 @@ from .errors import (
 from .requests import Request
 from .responses import BaseResponse, ErrorResponse
 
-LOG = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from asyncio.streams import StreamReader, StreamWriter
@@ -60,32 +60,32 @@ class JsonRPCClient:
 
     async def handle_cancellation(self, id: int) -> None:
         if self.ignore_cancellations:
-            return LOG.debug(f"Ignoring cancellation request of {id!r}")
+            return log.debug("Ignoring cancellation request of %r", id)
 
         if id in self.tasks:
             task = self.tasks.pop(id)
             success = task.cancel()
             if success:
-                LOG.info(f"Successfully cancelled task with id {id!r}")
+                log.debug("Successfully cancelled task with id %r", id)
             else:
-                LOG.exception(f"Failed to cancel task with id of {id!r}, task={task!r}")
+                log.exception("Failed to cancel task with id of %r, task=%r", id, task)
         else:
-            LOG.exception(
-                f"Failed to cancel task with id of {id!r}, could not find task."
+            log.exception(
+                "Failed to cancel task with id of %r, could not find task.", id
             )
 
     async def handle_result(self, result: dict) -> None:
         rid = result["id"]
 
-        LOG.debug(f"Result: {rid}, {result!r}")
+        log.debug("Result: %r, %r", rid, result)
         if rid in self.requests:
             try:
                 self.requests.pop(rid).set_result(result)
             except asyncio.InvalidStateError:
                 pass
         else:
-            LOG.exception(
-                f"Result from unknown request given. ID: {rid!r}, result={result!r}"
+            log.exception(
+                "Result from unknown request given. id=%r, result=%r", rid, result
             )
 
     async def handle_error(self, id: int, error: ErrorResponse) -> None:
@@ -94,7 +94,7 @@ class JsonRPCClient:
                 _get_jsonrpc_error_from_json(error.to_dict())
             )
         else:
-            LOG.error(f"Error response received for unknown request, {id=}")
+            log.error("Error response received for unknown request, id=%r", id)
 
     async def handle_notification(self, method: str, params: dict[str, Any]) -> None:
         if method == "$/cancelRequest":
@@ -102,8 +102,9 @@ class JsonRPCClient:
         else:
             err = MethodNotFound(f"Notification Method {method!r} Not Found")
 
-            LOG.exception(
-                f"Unknown notification method received: {method}",
+            log.exception(
+                "Unknown notification method received: %r",
+                method,
                 exc_info=err,
             )
 
@@ -121,8 +122,9 @@ class JsonRPCClient:
             task = self.plugin.dispatch(method, *params)
             if not task:
                 err = MethodNotFound(f"Request method {method!r} was not found")
-                LOG.exception(
-                    f"Unknown request method received: {method}",
+                log.exception(
+                    "Unknown request method received: %r",
+                    method,
                     exc_info=err,
                 )
                 return await self.write(err.to_response().to_message(id=request["id"]))
@@ -133,33 +135,33 @@ class JsonRPCClient:
         if isinstance(result, BaseResponse):
             return await self.write(result.to_message(id=request["id"]))
         err = InternalError("Internal Error: Invalid Response Object", repr(result))
-        LOG.exception(
-            f"Invalid Response Object: {result!r}",
+        log.exception(
+            "Invalid Response Object: %r",
+            result,
             exc_info=err,
         )
         return await self.write(err.to_response().to_message(id=request["id"]))
 
     async def process_input(self, line: str) -> None:
-        LOG.debug(f"Processing {line!r}")
         message = json.loads(line)
 
         if "id" not in message:
-            LOG.debug(f"Received notification: {message!r}")
+            log.debug("Received notification: %r", message)
             await self.handle_notification(message["method"], message["params"])
         elif "method" in message:
-            LOG.debug(f"Received request: {message!r}")
+            log.debug("Received request: %r", message)
             await self.handle_request(message)
         elif "result" in message:
-            LOG.debug(f"Received result: {message!r}")
+            log.debug("Received result: %r", message)
             await self.handle_result(message)
         elif "error" in message:
-            LOG.exception(f"Received error: {message!r}")
+            log.exception("Received error: %r", message)
             await self.handle_error(
                 message["id"], ErrorResponse.from_dict(message["error"])
             )
         else:
             err = InternalError("Unknown message type received", line)
-            LOG.exception(
+            log.exception(
                 "Unknown message type received",
                 exc_info=err,
             )
@@ -173,7 +175,7 @@ class JsonRPCClient:
 
         while 1:
             async for line in reader:
-                stream_log.info(f"Received line: {line!r} of type {type(line)!r}")
+                stream_log.debug("Received line: %r", line)
                 line = line.decode("utf-8")
                 if line == "":
                     continue
@@ -183,7 +185,7 @@ class JsonRPCClient:
                 task.add_done_callback(tasks.discard)
 
     async def write(self, msg: bytes, drain: bool = True) -> None:
-        LOG.debug(f"Sending: {msg!r}")
+        log.debug("Sending: %r", msg)
         self.writer.write(msg)
         if drain:
             await self.writer.drain()

--- a/flogin/jsonrpc/results.py
+++ b/flogin/jsonrpc/results.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine, Iterable
 
 TS = TypeVarTuple("TS")
-LOG = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 __all__ = ("Glyph", "ProgressBar", "Result", "ResultPreview")
 
@@ -234,9 +234,7 @@ class Result(Base, Generic[PluginT]):
         error: :class:`Exception`
             The error that occured
         """
-        LOG.exception(
-            f"Ignoring exception in result callback ({self!r})", exc_info=error
-        )
+        log.exception("Ignoring exception in result callback (%r)", exc_info=error)
         return ErrorResponse.internal_error(error)
 
     async def callback(self) -> ExecuteResponse | bool | None:
@@ -310,8 +308,9 @@ class Result(Base, Generic[PluginT]):
 
         @copy_doc(on_context_menu_error)
         async def on_context_menu_error(self, error: Exception) -> Any:
-            LOG.exception(
-                f"Ignoring exception in result's context menu callback ({self!r})",
+            log.exception(
+                "Ignoring exception in result's context menu callback (%r)",
+                self,
                 exc_info=error,
             )
             return ErrorResponse.internal_error(error)

--- a/flogin/pip.py
+++ b/flogin/pip.py
@@ -133,7 +133,7 @@ class Pip:
 
         if self._pip_fp:
             self._pip_fp.unlink(missing_ok=True)
-            log.info(f"Pip deleted from {self._pip_fp}")
+            log.info("Pip deleted from %s", self._pip_fp)
 
     def __enter__(self) -> Self:
         self.download_pip()
@@ -179,20 +179,18 @@ class Pip:
 
         pip = self._pip_fp.as_posix()
         cmd = [sys.executable, pip, *args]
-        log.debug(f"Sending command: {cmd!r}")
+        log.debug("Sending command: %r", cmd)
 
         try:
             proc = subprocess.run(cmd, capture_output=True, check=True)
         except subprocess.CalledProcessError as e:
-            log.debug(
-                f"Pip command failed. stdout: {e.output.decode()!r}, stderr: {e.stderr.decode()!r}"
-            )
+            log.debug("Pip command failed. stdout: %r, stderr: %r", e.output, e.stderr)
             raise PipExecutionError(e)
 
         output = proc.stdout.decode()
-        log.debug(f"Pip stdout: {output!r}")
+        log.debug("Pip stdout: %r", output)
         if proc.stderr:
-            log.debug(f"Pip stderr: {proc.stderr.decode()!r}")
+            log.debug("Pip stderr: %r", proc.stderr)
 
         return output
 

--- a/flogin/plugin.py
+++ b/flogin/plugin.py
@@ -60,7 +60,7 @@ TS = TypeVarTuple("TS")
 EventCallbackT = TypeVar(
     "EventCallbackT", bound=Callable[..., Coroutine[Any, Any, Any]]
 )
-LOG = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 __all__ = ("Plugin",)
 
@@ -169,7 +169,7 @@ class Plugin(Generic[SettingsT]):
         with open(fp) as f:
             data = json.load(f)
         self._settings_are_populated = True
-        LOG.debug(f"Settings filled from file: {data!r}")
+        log.debug("Settings filled from file: %r", data)
         return Settings(data, no_update=self.options.get("settings_no_update", False))  # type: ignore[reportReturnType]
 
     async def _run_event(
@@ -215,7 +215,7 @@ class Plugin(Generic[SettingsT]):
         }
         method = replacements.get(method, method)
 
-        LOG.debug("Dispatching event %s", method)
+        log.debug("Dispatching event %s", method)
 
         event_callback = self._events.get(method)
         if event_callback:
@@ -246,7 +246,7 @@ class Plugin(Generic[SettingsT]):
         return results
 
     async def _initialize_wrapper(self, arg: dict[str, Any]) -> ExecuteResponse:
-        LOG.info(f"Initialize: {json.dumps(arg)}")
+        log.debug("Initialize: %r", arg)
         self._metadata = PluginMetadata(arg["currentPluginMetadata"], self.api)
         self.dispatch("initialization")
         return ExecuteResponse(hide=False)
@@ -254,7 +254,7 @@ class Plugin(Generic[SettingsT]):
     async def process_context_menus(
         self, data: list[Any]
     ) -> QueryResponse | ErrorResponse:
-        LOG.debug(f"Context Menu Handler: {data=}")
+        log.debug("Context Menu Handler: data=%r", data)
 
         if not data:
             results = []
@@ -367,9 +367,7 @@ class Plugin(Generic[SettingsT]):
         try:
             asyncio.run(self.start())
         except Exception as e:
-            LOG.exception(
-                f"A fatal error has occured which crashed flogin: {e}", exc_info=e
-            )
+            log.exception("A fatal error has occured which crashed flogin", exc_info=e)
 
     def register_search_handler(self, handler: SearchHandler[Any]) -> None:
         r"""Register a new search handler
@@ -383,7 +381,7 @@ class Plugin(Generic[SettingsT]):
         """
 
         self._search_handlers.append(handler)
-        LOG.info(f"Registered search handler: {handler}")
+        log.debug("Registered search handler: %r", handler)
 
     def register_search_handlers(self, *handlers: SearchHandler[Any]) -> None:
         r"""Register new search handlers

--- a/flogin/plugin.py
+++ b/flogin/plugin.py
@@ -367,7 +367,7 @@ class Plugin(Generic[SettingsT]):
         try:
             asyncio.run(self.start())
         except Exception as e:
-            log.exception("A fatal error has occured which crashed flogin", exc_info=e)
+            log.exception("A fatal error has occurred which crashed flogin", exc_info=e)
 
     def register_search_handler(self, handler: SearchHandler[Any]) -> None:
         r"""Register a new search handler

--- a/flogin/search_handler.py
+++ b/flogin/search_handler.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
         bound=Callable[[Query, Exception], SearchHandlerCallbackReturns],
     )
 
-LOG = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 __all__ = ("SearchHandler",)
 
@@ -270,8 +270,9 @@ class SearchHandler(Generic[PluginT]):
 
         @copy_doc(on_error)
         async def on_error(self, query: Query, error: Exception) -> Any:
-            LOG.exception(
-                f"Ignoring exception in search handler callback ({self!r})",
+            log.exception(
+                "Ignoring exception in search handler callback (%r)",
+                self,
                 exc_info=error,
             )
             return ErrorResponse.internal_error(error)

--- a/flogin/settings.py
+++ b/flogin/settings.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, overload
 if TYPE_CHECKING:
     from ._types import RawSettings
 
-LOG = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 __all__ = ("Settings",)
 
@@ -81,16 +81,16 @@ class Settings:
 
     def _update(self, data: RawSettings) -> None:
         if self._no_update:
-            LOG.debug(f"Received a settings update, ignoring. {data=}")
+            log.debug("Received a settings update, ignoring. data=%r", data)
         else:
-            LOG.debug(f"Updating settings. Before: {self._data}, after: {data}")
+            log.debug("Updating settings. Before: %s, after: %s", self._data, data)
             self._data = data
 
     def _get_updates(self) -> RawSettings:
         try:
             return self._changes
         finally:
-            LOG.debug(f"Resetting setting changes: {self._changes}")
+            log.debug("Resetting setting changes: %s", self._changes)
             self._changes = {}
 
     def __repr__(self) -> str:

--- a/flogin/utils.py
+++ b/flogin/utils.py
@@ -30,8 +30,6 @@ Coro = TypeVar("Coro", bound=Callable[..., Coroutine[Any, Any, Any]])
 AGenT = TypeVar("AGenT", bound=Callable[..., AsyncGenerator[Any, Any]])
 T = TypeVar("T")
 
-LOG = logging.getLogger(__name__)
-
 
 class _cached_property(Generic[T]):
     def __init__(self, function: Callable[..., T]) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,6 @@ select = [
 ]
 ignore = [
     "F403", # https://docs.astral.sh/ruff/rules/undefined-local-with-import-star/#undefined-local-with-import-star-f403
-    "G004", # https://docs.astral.sh/ruff/rules/logging-f-string/
     "SIM105", # https://docs.astral.sh/ruff/rules/suppressible-exception/
     "E501", # https://docs.astral.sh/ruff/rules/#error-e_1
     "ANN401", # https://docs.astral.sh/ruff/rules/any-type/


### PR DESCRIPTION
## Summary

This PR rewrites the logging to delay the formatting of logs in the case of logs being disabled. It also moves some of the logs down from info level to debug level, and renames `LOG` to `log` for the internal loggers.

## Changelog

### Breaking Changes

<!-- Any breaking changes? -->

### New Features

<!-- Any new features? -->

### Bug Fixes

<!-- Any bug fixes? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Logging Changes**
	- Renamed logging variable from `LOG` to `log` across multiple files
	- Updated logging message formatting from f-strings to traditional string formatting
	- Removed some logging imports and configurations

- **Linting**
	- Removed linter rule ignoring f-string logging warnings in `pyproject.toml`

- **No Functional Changes**
	- Core functionality of modules remains unchanged
	- No modifications to method signatures or core logic
<!-- end of auto-generated comment: release notes by coderabbit.ai -->