### PR TITLE
57 resultconstructorargs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -88,6 +88,10 @@ Results
 .. autoclass:: flogin.jsonrpc.results.Glyph
     :members:
 
+.. attributetable:: flogin.jsonrpc.results.ResultConstructorKwargs
+
+.. autotypeddict:: flogin.jsonrpc.results.ResultConstructorKwargs
+
 Responses
 ~~~~~~~~~
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,6 +57,7 @@ extensions = [
     "sphinx_toolbox.more_autodoc.typevars",  # https://sphinx-toolbox.readthedocs.io/en/latest/extensions/more_autodoc/typevars.html
     "sphinxcontrib_trio",  # https://sphinxcontrib-trio.readthedocs.io/en/latest/
     "sphinx_copybutton",  # https://github.com/executablebooks/sphinx-copybutton#readme
+    "sphinx_toolbox.more_autodoc.autotypeddict", # https://sphinx-toolbox.readthedocs.io/en/v2.16.1/extensions/more_autodoc/autotypeddict.html
     "nitpick_file_ignorer",
     "attributetable",
 ]

--- a/flogin/jsonrpc/results.py
+++ b/flogin/jsonrpc/results.py
@@ -34,11 +34,10 @@ if TYPE_CHECKING:
         RawResult,
     )
 
-
 TS = TypeVarTuple("TS")
 log = logging.getLogger(__name__)
 
-__all__ = ("Glyph", "ProgressBar", "Result", "ResultPreview")
+__all__ = ("Glyph", "ProgressBar", "Result", "ResultConstructorKwargs", "ResultPreview")
 
 
 class Glyph(Base["RawGlyph"]):
@@ -135,20 +134,45 @@ class ResultPreview(Base["RawPreview"]):
         self.is_media = is_media
 
 
-class ResultConstructorArgs(TypedDict):
-    title: NotRequired[str | None]
-    sub: NotRequired[str | None]
-    icon: NotRequired[str | None]
-    title_highlight_data: NotRequired[Iterable[int] | None]
-    title_tooltip: NotRequired[str | None]
-    sub_tooltip: NotRequired[str | None]
-    copy_text: NotRequired[str | None]
-    score: NotRequired[int | None]
-    rounded_icon: NotRequired[bool | None]
-    glyph: NotRequired[Glyph | None]
-    auto_complete_text: NotRequired[str | None]
-    preview: NotRequired[ResultPreview | None]
-    progress_bar: NotRequired[ProgressBar | None]
+class ResultConstructorKwargs(TypedDict, total=False):
+    r"""This represents the possible kwargs that can be passed to :class:`Result`.
+
+    This can be useful when overriding :class:`Result` to create a basic implementation of something for your project, but still want the ability to pass kwargs with proper typing.
+
+    .. NOTE::
+        See :class:`Result` for more information about each key and value.
+
+    Example
+    --------
+    This is an example of how you might use this to create a url result
+
+    .. code-block:: py3
+
+        from typing import Unpack
+        from flogin import Result, ResultConstructorKwargs
+
+        class MyRes(Result):
+            def __init__(self, url: str, **kwargs: Unpack[ResultConstructorKwargs]) -> None:
+                self.url = url
+                super().__init__(**kwargs)
+
+            async def callback(self):
+                await self.plugin.api.open_url(self.url)
+    """
+
+    title: NotRequired[str]
+    sub: NotRequired[str]
+    icon: NotRequired[str]
+    title_highlight_data: NotRequired[list[int]]
+    title_tooltip: NotRequired[str]
+    sub_tooltip: NotRequired[str]
+    copy_text: NotRequired[str]
+    score: NotRequired[int]
+    rounded_icon: NotRequired[bool]
+    glyph: NotRequired[Glyph]
+    auto_complete_text: NotRequired[str]
+    preview: NotRequired[ResultPreview]
+    progress_bar: NotRequired[ProgressBar]
 
 
 class Result(Base["RawResult"], Generic[PluginT]):
@@ -417,7 +441,7 @@ class Result(Base["RawResult"], Generic[PluginT]):
     def create_with_partial(
         cls: type[Result],
         partial_callback: Callable[[], Coroutine[Any, Any, Any]],
-        **kwargs: Unpack[ResultConstructorArgs],
+        **kwargs: Unpack[ResultConstructorKwargs],
     ) -> Result:
         r"""A quick and easy way to create a result with a callback without subclassing.
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Changelog

### Breaking Changes

<!-- Any breaking changes? -->

### New Features

<!-- Any new features? -->

### Bug Fixes

<!-- Any bug fixes? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Enhanced API reference documentation for `ResultConstructorKwargs`
  - Added new Sphinx documentation extension for typed dictionary support

- **New Features**
  - Introduced `ResultConstructorKwargs` with flexible, optional constructor arguments for results

- **Refactor**
  - Updated `Result` class constructor to use new `ResultConstructorKwargs`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->