### PR TITLE
Lazy raise on pip download failure

### DIFF
--- a/flogin/errors.py
+++ b/flogin/errors.py
@@ -69,11 +69,11 @@ class UnableToDownloadPip(PipException):
 
     Attributes
     ----------
-    error: :class:`requests.exceptions.HTTPError` | :class:`requests.Timeout` | :class:`requests.ConnectionError`
+    error: :class:`requests.exceptions.HTTPError` | :class:`requests.Timeout` | :class:`requests.ConnectionError` | :class:`BaseException`
         The error that was raised by the :doc:`req:index` module.
     """
 
-    def __init__(self, err: requests.RequestException) -> None:
+    def __init__(self, err: BaseException) -> None:
         super().__init__(err)
         self.error = err
 

--- a/flogin/pip.py
+++ b/flogin/pip.py
@@ -190,7 +190,7 @@ class Pip:
         """
 
         if self._pip_fp is None and self.pip_download_err:
-            raise UnableToDownloadPip() from self.pip_download_err
+            raise UnableToDownloadPip(self.pip_download_err) from self.pip_download_err
         elif self._pip_fp is None:
             raise RuntimeError("Pip has not been installed")
 


### PR DESCRIPTION
## Summary

- Add lazy raise on pip download failure.
- Add bool return to `download_pip` as a result if pip downloaded

### Bug Fixes

- Fixed whole plugin crushing when all components passed `ensure_installed`

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.